### PR TITLE
feat(tools): add certificate generator free tool page

### DIFF
--- a/docs/plans/2026-04-13-001-feat-certificate-generator-tool-plan.md
+++ b/docs/plans/2026-04-13-001-feat-certificate-generator-tool-plan.md
@@ -1,0 +1,330 @@
+---
+title: "feat: Add certificate generator free tool page"
+type: feat
+status: completed
+date: 2026-04-13
+deepened: 2026-04-13
+---
+
+# feat: Add certificate generator free tool page
+
+## Overview
+
+Add a dedicated interactive certificate generator at `/tools/certificate-generator` targeting the "certificate generator" keyword cluster (2,900 monthly searches, difficulty 23). This is a PLG/SEO tool that uses the existing FabricJS rendering pipeline — zero backend changes required. The tool offers 4-5 certificate templates with an interactive canvas editor and variable input form, generating downloadable PNG images.
+
+## Problem Frame
+
+Orshot.com's `/tools/certificate-generator` is their #1 non-branded traffic page (199 ETV, 40 ranked keywords). Pictify currently has a generic pSEO page at `/tools/certificate` with basic MiniEditor integration, but it lacks template variety, a variable input form, and dedicated SEO targeting. A purpose-built tool page will capture this keyword cluster while showcasing Pictify's FabricJS canvas advantage over Orshot's simpler approach.
+
+## Requirements Trace
+
+- R1. Dedicated route at `/tools/certificate-generator` with keyword-optimized SEO (title, meta, schema)
+- R2. 4-5 visually distinct certificate templates as FabricJS JSON, each with variable bindings for recipientName, organizationName, date, achievementText
+- R3. Interactive canvas preview via MiniEditor with form-driven variable input that syncs to the canvas live
+- R4. Image generation via existing `POST /image/public/canvas` endpoint — watermarked for guests
+- R5. Post-generation flow using existing NextSteps, GenerationLimitBanner, and "Open in Full Editor" CTA
+- R6. Mobile-responsive layout (form + canvas side-by-side on desktop, stacked on mobile)
+- R7. Tools index page updated to include Certificate Generator
+- R8. pSEO certificate config updated with link to dedicated tool
+
+## Scope Boundaries
+
+- No backend changes — uses existing `/image/public/canvas` endpoint
+- No PDF download (Phase 2)
+- No CSV bulk generation (Phase 2)
+- No logo/signature upload (Phase 2)
+- No QR verification codes (Phase 2)
+- No new API functions in `src/api/image.js` — call `backend.post()` directly (matches `[usecase]` page pattern)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Primary pattern:** `src/routes/tools/[usecase]/+page.svelte` — MiniEditor integration, `backend.post('/image/public/canvas', ...)`, template loading via `getTemplateForUseCase()`, NextSteps binding, generation state management
+- **SEO pattern:** `src/routes/tools/online-invoice-generator/+page.svelte` — WebApplication + FAQPage schema, meta tags, OG tags, canonical URL, breadcrumbs
+- **MiniEditor API:** `src/lib/components/tools/MiniEditor.svelte` — props: `fabricJSData`, `width`, `height`; exported: `getEditedFabricData()`; makes text objects click-to-edit, locks non-text objects
+- **Template definition pattern:** `src/lib/pseo/useCaseTemplates.js:getCertificateTemplate()` (line 217) — FabricJS v6 objects with `isVariable: true` and `variableBindings` array
+- **Component interfaces:**
+  - `NextSteps`: props `heading`, `description`, `curlSnippet`, `templateDraft`, `generatedUrl`, `generatedWidth`, `generatedHeight`, `generatedFormat`, `toolName`
+  - `GenerationLimitBanner`: prop `toolName`
+  - `RelatedTools`: prop `tools` (array of use-case IDs)
+- **Neo-brutalist style:** `border-[3px] border-gray-900`, `shadow-[4px_4px_0_0_#...]`, accent `#ffc480`, font `Manrope`
+
+### Institutional Learnings
+
+- The `[usecase]` page generation flow is battle-tested — uses `backend.post('/image/public/canvas')` directly, not a named API function
+- MiniEditor disposes canvases properly on template switch via generation counter pattern (`loadGeneration`)
+- Variable bindings use `variableBindings[0].variableName` to match objects to variable names
+
+## Key Technical Decisions
+
+- **Dedicated route over pSEO upgrade:** A custom page at `/tools/certificate-generator` gives full SEO control (exact keyword in title/H1/URL) and allows certificate-specific UX (variable form, template gallery). The pSEO page at `/tools/certificate` remains as a complementary landing page.
+- **Extend MiniEditor with `setVariableValue()`:** Adds a method to programmatically update text objects from the variable form. This is backwards-compatible — existing pages don't call it. Alternative was manipulating `fabricJSData` prop and re-triggering load, but that recreates the entire canvas on each keystroke.
+- **Templates as JS module, not backend HTML:** Certificate templates are FabricJS JSON objects in a JS file, following the `useCaseTemplates.js` pattern. No need for a backend template-serving route (unlike invoice which uses HTML files on disk).
+- **Debounce form-to-canvas sync at 150ms:** Prevents excessive `renderAll()` calls during fast typing.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should we create a `createPublicCanvasImage()` function in `src/api/image.js`?** No — the `[usecase]` page calls `backend.post()` directly. Follow the same pattern for consistency.
+- **Where do template thumbnails come from?** Each template definition includes a static `thumbnailBgColor` and `thumbnailLabel` for the gallery cards. No pre-rendered images needed — cards show a color swatch + template name.
+
+### Deferred to Implementation
+
+- **Exact FabricJS coordinates and styling for templates 2-5:** Will be determined during implementation by creating visually distinct designs. The approach (objects array with variable bindings) is fixed.
+- **Exact FAQ content for schema:** Will be written during implementation to target certificate-related long-tail keywords.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+User Flow:
+  
+  1. Template Gallery (horizontal scroll of 4-5 cards)
+     │
+     ├── Select template → MiniEditor loads new fabricJSData
+     │                      Form resets to template defaults
+     │
+  2. Variable Form (left) + MiniEditor Canvas (right)
+     │
+     ├── Type in form → debounced setVariableValue() → canvas re-renders
+     ├── Click text on canvas → edit inline (existing MiniEditor behavior)
+     │
+  3. Generate Button
+     │
+     ├── getEditedFabricData() → POST /image/public/canvas
+     ├── watermark: !isUserLoggedIn
+     │
+  4. Result Section
+     │
+     ├── Image preview + Download button
+     ├── NextSteps (API snippet, save as template, batch info)
+     ├── GenerationLimitBanner (for guests)
+     └── "Open in Full Editor" CTA
+
+MiniEditor Extension:
+  
+  setVariableValue(name, value):
+    find object where variableBindings[0].variableName === name
+    set object.text = value
+    fabricCanvas.renderAll()
+  
+  getVariables():
+    filter objects with variableBindings
+    return [{name, value, description}]
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend MiniEditor with variable control methods**
+
+  **Goal:** Add `setVariableValue()` and `getVariables()` exported functions to MiniEditor, plus error state for failed canvas loads.
+
+  **Requirements:** R3
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `src/lib/components/tools/MiniEditor.svelte`
+
+  **Approach:**
+  - Add `export function setVariableValue(variableName, value)` — iterates `fabricCanvas.getObjects()`, finds object where `variableBindings` array contains matching `variableName`, sets `.text` property, calls `fabricCanvas.renderAll()`
+  - Add `export function getVariables()` — filters objects with `variableBindings`, returns array of `{ name: binding.variableName, value: obj.text, description: binding.description }`
+  - Add `let loadError = false` state variable. Set to `true` in the catch block of `loadCanvas()`. Reset to `false` at the start of each `loadCanvas()` call.
+  - Add error UI: when `loadError` is true, show a message instead of the canvas
+  - Guard clauses: early return if `fabricCanvas` is null in both new methods
+  - Must not change any existing behavior — all existing props, exports, and event handling remain identical
+
+  **Patterns to follow:**
+  - Existing `getEditedFabricData()` export pattern in the same file
+  - Variable binding structure from `useCaseTemplates.js`: `obj.variableBindings[0].variableName`
+
+  **Test scenarios:**
+  - Happy path: `setVariableValue('recipientName', 'John Doe')` updates the matching text object's `.text` property to 'John Doe'
+  - Happy path: `getVariables()` returns array with correct name, value, description for each variable object
+  - Edge case: `setVariableValue()` called before canvas initialized — no-ops without error
+  - Edge case: `setVariableValue()` called with non-existent variable name — no-ops without error
+  - Edge case: `getVariables()` called on canvas with no variable objects — returns empty array
+  - Error path: `loadCanvas()` with malformed fabricJSData — sets `loadError = true`, shows error UI
+
+  **Verification:**
+  - Existing `[usecase]` pages still work identically (no regression)
+  - New methods are callable from a parent component via `bind:this` ref
+
+- [ ] **Unit 2: Create certificate template definitions**
+
+  **Goal:** Define 4-5 visually distinct certificate FabricJS templates with consistent variable bindings.
+
+  **Requirements:** R2
+
+  **Dependencies:** None (can run in parallel with Unit 1)
+
+  **Files:**
+  - Create: `src/lib/components/tools/CertificateTemplates.js`
+
+  **Approach:**
+  - Export an array `certificateTemplates` and individual factory functions
+  - Template #1 (Elegant): Port `getCertificateTemplate()` from `useCaseTemplates.js` — cream background, gold borders, Georgia font
+  - Template #2 (Modern): Dark background (#1a1a2e), clean sans-serif (Inter), accent gradient bar, minimal borders
+  - Template #3 (Corporate): White background, navy (#1e3a5f) header bar, professional layout, subtle gray borders
+  - Template #4 (Minimalist): Pure white, thin gray borders, large centered typography, lots of whitespace
+  - Template #5 (Creative): Colorful accent (#ff6b6b or similar), diagonal decorative elements, playful but professional
+  - Each template: `{ id, name, description, thumbnailColor, width: 1920, height: 1080, fabricJSData }` 
+  - Every template must have these variable bindings: `recipientName`, `organizationName`, `date`, `achievementText`
+  - All templates use 1920x1080 landscape orientation
+  - Use `generateId()` helper (import from useCaseTemplates.js or inline UUID function)
+
+  **Patterns to follow:**
+  - `src/lib/pseo/useCaseTemplates.js:getCertificateTemplate()` — exact object structure, variable binding format, FabricJS v6 schema
+
+  **Test scenarios:**
+  - Happy path: Each template returns a valid object with `id`, `name`, `width`, `height`, and `fabricJSData` with non-empty `objects` array
+  - Happy path: Each template's `fabricJSData.objects` contains at least 4 variable-bound textbox objects (recipientName, organizationName, date, achievementText)
+  - Edge case: All template IDs are unique
+  - Edge case: All templates use width=1920 and height=1080
+
+  **Verification:**
+  - Templates can be loaded by MiniEditor without error
+  - Variable bindings match the expected names used by the form
+
+- [ ] **Unit 3: Build the certificate generator page**
+
+  **Goal:** Create the main tool page with template gallery, variable form, MiniEditor canvas, generation flow, and full SEO.
+
+  **Requirements:** R1, R3, R4, R5, R6
+
+  **Dependencies:** Unit 1 (MiniEditor extensions), Unit 2 (templates)
+
+  **Files:**
+  - Create: `src/routes/tools/certificate-generator/+page.svelte`
+
+  **Approach:**
+
+  *Page structure (top to bottom):*
+  1. `<svelte:head>` — SEO title, meta description, canonical, OG tags, Twitter cards, WebApplication schema, FAQPage schema
+  2. Nav component
+  3. Breadcrumb: Home / Tools / Certificate Generator
+  4. Hero section: badge ("Free Tool"), H1 "CERTIFICATE GENERATOR", description
+  5. GenerationLimitBanner
+  6. Template gallery: horizontal row of template cards with thumbnail color + name, click to select
+  7. Main editor section (responsive grid):
+     - Left column (desktop) / top (mobile): Variable form with labeled inputs
+     - Right column (desktop) / bottom (mobile): MiniEditor canvas preview
+  8. Generate button (prominent, centered below editor)
+  9. Result section (shown after generation): image preview, download button
+  10. NextSteps component
+  11. "Open in Full Editor" CTA section
+  12. FAQ section (5-6 questions for SEO, also in FAQPage schema)
+  13. RelatedTools section
+  14. Footer component
+
+  *State management:*
+  - `selectedTemplate` — current template object (defaults to first)
+  - `formValues` — `{ recipientName, organizationName, date, achievementText }` with sensible defaults
+  - `isGenerating`, `generatedImageUrl`, `generationError` — generation state
+  - `miniEditorRef` — bound reference to MiniEditor
+  - `isUserLoggedIn` — from user store subscription
+
+  *Form-to-canvas sync:*
+  - Reactive statement watches `formValues` changes
+  - Debounced at 150ms before calling `miniEditorRef.setVariableValue()` for each changed field
+  - On template switch: reset `formValues` to new template's defaults, MiniEditor reloads via reactive `fabricJSData` prop change
+
+  *Generation flow:*
+  - Follows exact `[usecase]` page pattern: `generationLimits.increment()`, `backend.post('/image/public/canvas', ...)`, toast notifications, error handling for 429/500
+  - `templateDraft` for NextSteps: `{ version: 1, name: 'Certificate template', type: 'certificate', width: 1920, height: 1080, fabricJSData: editedData, source: 'certificate-generator' }`
+  - API curl snippet built from current template data
+
+  *SEO:*
+  - Title: "Free Certificate Generator Online | Create Custom Certificates | Pictify.io"
+  - H1: "CERTIFICATE GENERATOR" (neo-brutalist styled)
+  - WebApplication schema with `applicationCategory: ['DesignApplication', 'Utility']`
+  - FAQPage schema with 5-6 certificate-specific questions
+  - Canonical: `https://pictify.io/tools/certificate-generator`
+
+  *Analytics:*
+  - `onMount`: `analytics.trackToolOpened({ tool_name: 'certificate_generator' })`
+  - On generate: `analytics.trackImageGenerated({ tool_name: 'certificate_generator', format: 'png', with_watermark: !isUserLoggedIn })`
+
+  **Patterns to follow:**
+  - `src/routes/tools/[usecase]/+page.svelte` — generation flow, MiniEditor binding, NextSteps integration, template loading
+  - `src/routes/tools/online-invoice-generator/+page.svelte` — page structure, SEO markup, breadcrumbs, hero section, neo-brutalist styling
+
+  **Test scenarios:**
+  - Happy path: Page loads with default template rendered in MiniEditor canvas
+  - Happy path: Selecting a different template updates the canvas preview
+  - Happy path: Typing in variable form updates text on canvas after debounce
+  - Happy path: Generate button calls `/image/public/canvas` and displays result image
+  - Happy path: NextSteps appears after successful generation with correct props
+  - Edge case: Double-click generate — button disabled while `isGenerating` is true
+  - Edge case: Generate before canvas ready — uses fallback template data via `getEditedFabricData() || selectedTemplate.fabricJSData`
+  - Edge case: Mobile viewport — form and canvas stack vertically
+  - Error path: 429 rate limit — shows "Too many requests" toast
+  - Error path: 500 server error — shows "Failed to generate" toast
+  - Error path: Canvas load failure — MiniEditor shows error state (from Unit 1)
+  - Integration: Template switch resets form values and reloads canvas with new fabricJSData
+
+  **Verification:**
+  - Page accessible at `/tools/certificate-generator`
+  - All 5 templates selectable and renderable
+  - Form updates reflect on canvas in real-time
+  - Generated image URL loads a valid PNG
+  - SEO: view source shows correct title, meta, schema markup
+  - Mobile: layout stacks correctly on narrow viewports
+
+- [ ] **Unit 4: Update tools index and pSEO config**
+
+  **Goal:** Add Certificate Generator to the tools index page and link the pSEO certificate config to the dedicated tool page.
+
+  **Requirements:** R7, R8
+
+  **Dependencies:** Unit 3
+
+  **Files:**
+  - Modify: `src/routes/tools/+page.svelte`
+  - Modify: `src/lib/pseo/use-cases.js`
+
+  **Approach:**
+  - Tools index: Add a new card in the featured tools grid linking to `/tools/certificate-generator` with appropriate icon/description. Place it logically near Invoice Generator (both are document-type tools).
+  - pSEO config: Add `toolUrl: '/tools/certificate-generator'` to the `certificate` use-case detail object at line ~534. This allows the pSEO page to link users to the dedicated interactive tool.
+
+  **Patterns to follow:**
+  - Existing tool cards in `src/routes/tools/+page.svelte` for card structure and linking
+  - Other use-case configs that reference dedicated tool pages (if any exist)
+
+  **Test scenarios:**
+  - Happy path: Tools index page shows Certificate Generator card with correct link
+  - Happy path: Clicking the card navigates to `/tools/certificate-generator`
+  - Integration: pSEO page at `/tools/certificate` shows a link/CTA to the dedicated tool page
+
+  **Verification:**
+  - `/tools` page renders the new card
+  - Navigation from tools index to certificate generator works
+  - No broken links or layout regressions on the tools index
+
+## System-Wide Impact
+
+- **Interaction graph:** MiniEditor gains two new exported functions. All existing callers (`[usecase]` page) are unaffected — they don't call these methods. The new page is the only consumer.
+- **Error propagation:** Generation errors follow the existing toast pattern. No new error types introduced.
+- **State lifecycle risks:** Template switching disposes and recreates the FabricJS canvas via MiniEditor's existing `loadGeneration` counter pattern. Form state resets on template change — no stale state risk.
+- **API surface parity:** No new API endpoints. Uses existing public canvas endpoint identically to `[usecase]` pages.
+- **Unchanged invariants:** All existing tool pages, the pSEO `[usecase]` route, the MiniEditor component's existing behavior, and the backend `/image/public/canvas` endpoint remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| FabricJS template designs look bad | Start from the proven `getCertificateTemplate()` design; iterate on 4 new designs with distinct visual themes |
+| MiniEditor `setVariableValue()` doesn't find objects due to serialization | Variable bindings with `isVariable: true` are included in `toJSON()` for textbox objects — verified in existing template usage |
+| Rate limit (5/min) frustrates users | GenerationLimitBanner already handles this UX; matches all other tool pages |
+| Page competes with own `/tools/certificate` pSEO page | Different URL slug targets different keyword intents ("certificate generator" vs "certificate from HTML"); canonical tags prevent duplicate content |
+
+## Sources & References
+
+- Related code: `src/routes/tools/[usecase]/+page.svelte` (generation flow pattern)
+- Related code: `src/routes/tools/online-invoice-generator/+page.svelte` (page structure pattern)
+- Related code: `src/lib/components/tools/MiniEditor.svelte` (canvas component)
+- Related code: `src/lib/pseo/useCaseTemplates.js:getCertificateTemplate()` (template #1 source)
+- SEO data: "certificate generator" 2,900 vol / difficulty 23 — Orshot at pos 7

--- a/src/lib/components/tools/CertificateTemplates.js
+++ b/src/lib/components/tools/CertificateTemplates.js
@@ -1,0 +1,1507 @@
+const generateId = () => Math.random().toString(36).substring(2, 10);
+
+/**
+ * Template 1: Elegant/Classic
+ * Cream background, gold borders, Georgia font, decorative dashed inner border.
+ * Ported from getCertificateTemplate() in useCaseTemplates.js with added achievementText variable.
+ */
+function getElegantTemplate() {
+	return {
+		id: 'elegant',
+		name: 'Elegant',
+		description: 'Classic formal certificate with gold borders and elegant serif typography',
+		thumbnailColor: '#c8a76b',
+		width: 1920,
+		height: 1080,
+		fabricJSData: {
+			version: '6.0.0',
+			objects: [
+				// Cream background
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 0,
+					width: 1920,
+					height: 1080,
+					fill: '#fefbf0',
+					selectable: false,
+					evented: false
+				},
+				// Decorative outer border
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 60,
+					top: 60,
+					width: 1800,
+					height: 960,
+					fill: '#ffffff',
+					stroke: '#c8a76b',
+					strokeWidth: 6,
+					rx: 24,
+					ry: 24
+				},
+				// Inner decorative dashed border
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 90,
+					top: 90,
+					width: 1740,
+					height: 900,
+					fill: 'transparent',
+					stroke: '#c8a76b',
+					strokeWidth: 2,
+					strokeDashArray: [10, 5],
+					rx: 18,
+					ry: 18
+				},
+				// Corner flourish top-left
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 80,
+					top: 80,
+					width: 40,
+					height: 40,
+					fill: '#c8a76b',
+					rx: 4,
+					ry: 4,
+					opacity: 0.3
+				},
+				// Corner flourish top-right
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 1800,
+					top: 80,
+					width: 40,
+					height: 40,
+					fill: '#c8a76b',
+					rx: 4,
+					ry: 4,
+					opacity: 0.3
+				},
+				// Corner flourish bottom-left
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 80,
+					top: 960,
+					width: 40,
+					height: 40,
+					fill: '#c8a76b',
+					rx: 4,
+					ry: 4,
+					opacity: 0.3
+				},
+				// Corner flourish bottom-right
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 1800,
+					top: 960,
+					width: 40,
+					height: 40,
+					fill: '#c8a76b',
+					rx: 4,
+					ry: 4,
+					opacity: 0.3
+				},
+				// Certificate title
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 140,
+					width: 1680,
+					text: 'CERTIFICATE OF ACHIEVEMENT',
+					fontSize: 24,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#3b2f21',
+					textAlign: 'center',
+					letterSpacing: 400
+				},
+				// Organization name (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 200,
+					width: 1680,
+					text: 'Your Organization Name',
+					fontSize: 56,
+					fontWeight: 'bold',
+					fontFamily: 'Georgia',
+					fill: '#3b2f21',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'organizationName',
+							property: 'text',
+							description: 'Name of the organization'
+						}
+					]
+				},
+				// "This certifies that" text
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 320,
+					width: 1680,
+					text: 'This certificate is proudly presented to',
+					fontSize: 20,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#6b5b47',
+					textAlign: 'center'
+				},
+				// Recipient name (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 380,
+					width: 1680,
+					text: 'Recipient Name',
+					fontSize: 64,
+					fontWeight: 'bold',
+					fontFamily: 'Georgia',
+					fill: '#3b2f21',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'recipientName',
+							property: 'text',
+							description: 'Name of the certificate recipient'
+						}
+					]
+				},
+				// Achievement text (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 500,
+					width: 1520,
+					text: 'for successfully completing the Advanced JavaScript Course',
+					fontSize: 22,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#6b5b47',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'achievementText',
+							property: 'text',
+							description: 'Description of the achievement'
+						}
+					]
+				},
+				// Decorative gold divider line
+				{
+					type: 'line',
+					id: generateId(),
+					left: 660,
+					top: 570,
+					x1: 0,
+					y1: 0,
+					x2: 600,
+					y2: 0,
+					stroke: '#c8a76b',
+					strokeWidth: 2
+				},
+				// Date label
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 600,
+					width: 1520,
+					text: 'Awarded on',
+					fontSize: 16,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#6b5b47',
+					textAlign: 'center'
+				},
+				// Date (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 635,
+					width: 1520,
+					text: 'December 14, 2024',
+					fontSize: 28,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#3b2f21',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'date',
+							property: 'text',
+							description: 'Date of certificate issuance'
+						}
+					]
+				},
+				// Signature line 1
+				{
+					type: 'line',
+					id: generateId(),
+					left: 300,
+					top: 800,
+					x1: 0,
+					y1: 0,
+					x2: 300,
+					y2: 0,
+					stroke: '#3b2f21',
+					strokeWidth: 2
+				},
+				// Signature label 1
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 300,
+					top: 810,
+					width: 300,
+					text: 'Instructor',
+					fontSize: 16,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#6b5b47',
+					textAlign: 'center'
+				},
+				// Signature line 2
+				{
+					type: 'line',
+					id: generateId(),
+					left: 1320,
+					top: 800,
+					x1: 0,
+					y1: 0,
+					x2: 300,
+					y2: 0,
+					stroke: '#3b2f21',
+					strokeWidth: 2
+				},
+				// Signature label 2
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 1320,
+					top: 810,
+					width: 300,
+					text: 'Program Director',
+					fontSize: 16,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#6b5b47',
+					textAlign: 'center'
+				}
+			],
+			background: '#fefbf0'
+		}
+	};
+}
+
+/**
+ * Template 2: Modern Dark
+ * Dark background (#1a1a2e), white text, Inter font, purple accent bar (#6c63ff), clean minimal layout.
+ */
+function getModernDarkTemplate() {
+	return {
+		id: 'modern-dark',
+		name: 'Modern Dark',
+		description: 'Sleek dark theme with purple accents and clean sans-serif typography',
+		thumbnailColor: '#6c63ff',
+		width: 1920,
+		height: 1080,
+		fabricJSData: {
+			version: '6.0.0',
+			objects: [
+				// Dark background
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 0,
+					width: 1920,
+					height: 1080,
+					fill: '#1a1a2e',
+					selectable: false,
+					evented: false
+				},
+				// Top accent bar
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 0,
+					width: 1920,
+					height: 8,
+					fill: '#6c63ff',
+					selectable: false,
+					evented: false
+				},
+				// Bottom accent bar
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 1072,
+					width: 1920,
+					height: 8,
+					fill: '#6c63ff',
+					selectable: false,
+					evented: false
+				},
+				// Left vertical accent line
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 100,
+					top: 80,
+					width: 4,
+					height: 920,
+					fill: '#6c63ff',
+					opacity: 0.6
+				},
+				// Certificate title
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 160,
+					top: 120,
+					width: 1640,
+					text: 'CERTIFICATE',
+					fontSize: 20,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#6c63ff',
+					textAlign: 'left',
+					letterSpacing: 600
+				},
+				// Of achievement subtitle
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 160,
+					top: 160,
+					width: 1640,
+					text: 'OF ACHIEVEMENT',
+					fontSize: 48,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#ffffff',
+					textAlign: 'left'
+				},
+				// Thin separator line
+				{
+					type: 'line',
+					id: generateId(),
+					left: 160,
+					top: 240,
+					x1: 0,
+					y1: 0,
+					x2: 200,
+					y2: 0,
+					stroke: '#6c63ff',
+					strokeWidth: 3
+				},
+				// "Presented to" text
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 160,
+					top: 280,
+					width: 1640,
+					text: 'This certificate is presented to',
+					fontSize: 18,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#8888a8',
+					textAlign: 'left'
+				},
+				// Recipient name (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 160,
+					top: 330,
+					width: 1640,
+					text: 'Recipient Name',
+					fontSize: 72,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#ffffff',
+					textAlign: 'left',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'recipientName',
+							property: 'text',
+							description: 'Name of the certificate recipient'
+						}
+					]
+				},
+				// Achievement text (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 160,
+					top: 450,
+					width: 1520,
+					text: 'for successfully completing the Advanced JavaScript Course',
+					fontSize: 22,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#8888a8',
+					textAlign: 'left',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'achievementText',
+							property: 'text',
+							description: 'Description of the achievement'
+						}
+					]
+				},
+				// Organization name (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 160,
+					top: 540,
+					width: 1640,
+					text: 'Your Organization Name',
+					fontSize: 32,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#6c63ff',
+					textAlign: 'left',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'organizationName',
+							property: 'text',
+							description: 'Name of the organization'
+						}
+					]
+				},
+				// Date label
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 160,
+					top: 700,
+					width: 400,
+					text: 'DATE',
+					fontSize: 12,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#6c63ff',
+					textAlign: 'left',
+					letterSpacing: 300
+				},
+				// Date (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 160,
+					top: 725,
+					width: 400,
+					text: 'December 14, 2024',
+					fontSize: 20,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#ffffff',
+					textAlign: 'left',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'date',
+							property: 'text',
+							description: 'Date of certificate issuance'
+						}
+					]
+				},
+				// Signature line 1
+				{
+					type: 'line',
+					id: generateId(),
+					left: 160,
+					top: 880,
+					x1: 0,
+					y1: 0,
+					x2: 300,
+					y2: 0,
+					stroke: '#444466',
+					strokeWidth: 1
+				},
+				// Signature label 1
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 160,
+					top: 890,
+					width: 300,
+					text: 'Instructor',
+					fontSize: 14,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#8888a8',
+					textAlign: 'center'
+				},
+				// Signature line 2
+				{
+					type: 'line',
+					id: generateId(),
+					left: 600,
+					top: 880,
+					x1: 0,
+					y1: 0,
+					x2: 300,
+					y2: 0,
+					stroke: '#444466',
+					strokeWidth: 1
+				},
+				// Signature label 2
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 600,
+					top: 890,
+					width: 300,
+					text: 'Director',
+					fontSize: 14,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#8888a8',
+					textAlign: 'center'
+				},
+				// Decorative circle element top-right
+				{
+					type: 'circle',
+					id: generateId(),
+					left: 1680,
+					top: 80,
+					radius: 80,
+					fill: 'transparent',
+					stroke: '#6c63ff',
+					strokeWidth: 1,
+					opacity: 0.2
+				},
+				// Decorative circle element top-right (smaller)
+				{
+					type: 'circle',
+					id: generateId(),
+					left: 1720,
+					top: 120,
+					radius: 40,
+					fill: 'transparent',
+					stroke: '#6c63ff',
+					strokeWidth: 1,
+					opacity: 0.15
+				}
+			],
+			background: '#1a1a2e'
+		}
+	};
+}
+
+/**
+ * Template 3: Corporate
+ * White background, navy blue (#1e3a5f) header rectangle, professional serif+sans mix,
+ * subtle gray bottom border, formal and businesslike.
+ */
+function getCorporateTemplate() {
+	return {
+		id: 'corporate',
+		name: 'Corporate',
+		description: 'Professional corporate design with navy header and formal layout',
+		thumbnailColor: '#1e3a5f',
+		width: 1920,
+		height: 1080,
+		fabricJSData: {
+			version: '6.0.0',
+			objects: [
+				// White background
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 0,
+					width: 1920,
+					height: 1080,
+					fill: '#ffffff',
+					selectable: false,
+					evented: false
+				},
+				// Navy header band
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 0,
+					width: 1920,
+					height: 200,
+					fill: '#1e3a5f'
+				},
+				// Gold accent strip below header
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 200,
+					width: 1920,
+					height: 6,
+					fill: '#c9a84c'
+				},
+				// Subtle gray bottom border
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 1060,
+					width: 1920,
+					height: 20,
+					fill: '#1e3a5f'
+				},
+				// Certificate title in header
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 50,
+					width: 1680,
+					text: 'CERTIFICATE OF ACHIEVEMENT',
+					fontSize: 28,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#ffffff',
+					textAlign: 'center',
+					letterSpacing: 500
+				},
+				// Organization name in header (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 110,
+					width: 1680,
+					text: 'Your Organization Name',
+					fontSize: 44,
+					fontWeight: 'bold',
+					fontFamily: 'Georgia',
+					fill: '#ffffff',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'organizationName',
+							property: 'text',
+							description: 'Name of the organization'
+						}
+					]
+				},
+				// "This certifies that" text
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 280,
+					width: 1680,
+					text: 'This is to certify that',
+					fontSize: 20,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#666666',
+					textAlign: 'center'
+				},
+				// Recipient name (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 340,
+					width: 1680,
+					text: 'Recipient Name',
+					fontSize: 68,
+					fontWeight: 'bold',
+					fontFamily: 'Georgia',
+					fill: '#1e3a5f',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'recipientName',
+							property: 'text',
+							description: 'Name of the certificate recipient'
+						}
+					]
+				},
+				// Underline below recipient name
+				{
+					type: 'line',
+					id: generateId(),
+					left: 460,
+					top: 430,
+					x1: 0,
+					y1: 0,
+					x2: 1000,
+					y2: 0,
+					stroke: '#c9a84c',
+					strokeWidth: 2
+				},
+				// Achievement text (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 470,
+					width: 1520,
+					text: 'for successfully completing the Advanced JavaScript Course',
+					fontSize: 22,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#444444',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'achievementText',
+							property: 'text',
+							description: 'Description of the achievement'
+						}
+					]
+				},
+				// Date label
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 560,
+					width: 1520,
+					text: 'Date of Issuance',
+					fontSize: 14,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#999999',
+					textAlign: 'center',
+					letterSpacing: 200
+				},
+				// Date (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 590,
+					width: 1520,
+					text: 'December 14, 2024',
+					fontSize: 26,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#1e3a5f',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'date',
+							property: 'text',
+							description: 'Date of certificate issuance'
+						}
+					]
+				},
+				// Left decorative vertical stripe
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 60,
+					top: 240,
+					width: 3,
+					height: 760,
+					fill: '#e8e8e8'
+				},
+				// Right decorative vertical stripe
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 1857,
+					top: 240,
+					width: 3,
+					height: 760,
+					fill: '#e8e8e8'
+				},
+				// Signature line 1
+				{
+					type: 'line',
+					id: generateId(),
+					left: 300,
+					top: 860,
+					x1: 0,
+					y1: 0,
+					x2: 350,
+					y2: 0,
+					stroke: '#1e3a5f',
+					strokeWidth: 2
+				},
+				// Signature label 1
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 300,
+					top: 872,
+					width: 350,
+					text: 'Authorized Signatory',
+					fontSize: 14,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#888888',
+					textAlign: 'center'
+				},
+				// Signature line 2
+				{
+					type: 'line',
+					id: generateId(),
+					left: 1270,
+					top: 860,
+					x1: 0,
+					y1: 0,
+					x2: 350,
+					y2: 0,
+					stroke: '#1e3a5f',
+					strokeWidth: 2
+				},
+				// Signature label 2
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 1270,
+					top: 872,
+					width: 350,
+					text: 'Executive Director',
+					fontSize: 14,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#888888',
+					textAlign: 'center'
+				},
+				// Certificate number placeholder
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 970,
+					width: 1680,
+					text: 'Certificate No. 2024-001',
+					fontSize: 12,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#bbbbbb',
+					textAlign: 'center',
+					letterSpacing: 200
+				}
+			],
+			background: '#ffffff'
+		}
+	};
+}
+
+/**
+ * Template 4: Minimalist
+ * Pure white background, very thin gray border (#e5e7eb), large centered Inter typography,
+ * lots of whitespace, understated elegance.
+ */
+function getMinimalistTemplate() {
+	return {
+		id: 'minimalist',
+		name: 'Minimalist',
+		description: 'Clean minimal design with generous whitespace and refined typography',
+		thumbnailColor: '#374151',
+		width: 1920,
+		height: 1080,
+		fabricJSData: {
+			version: '6.0.0',
+			objects: [
+				// White background
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 0,
+					width: 1920,
+					height: 1080,
+					fill: '#ffffff',
+					selectable: false,
+					evented: false
+				},
+				// Thin outer border
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 40,
+					top: 40,
+					width: 1840,
+					height: 1000,
+					fill: 'transparent',
+					stroke: '#e5e7eb',
+					strokeWidth: 1
+				},
+				// Certificate label
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 140,
+					width: 1680,
+					text: 'CERTIFICATE',
+					fontSize: 14,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#9ca3af',
+					textAlign: 'center',
+					letterSpacing: 800
+				},
+				// Title
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 180,
+					width: 1680,
+					text: 'of Achievement',
+					fontSize: 44,
+					fontWeight: 'normal',
+					fontFamily: 'Georgia',
+					fill: '#374151',
+					textAlign: 'center'
+				},
+				// Thin horizontal rule
+				{
+					type: 'line',
+					id: generateId(),
+					left: 860,
+					top: 260,
+					x1: 0,
+					y1: 0,
+					x2: 200,
+					y2: 0,
+					stroke: '#d1d5db',
+					strokeWidth: 1
+				},
+				// "Presented to" text
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 300,
+					width: 1680,
+					text: 'Presented to',
+					fontSize: 16,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#9ca3af',
+					textAlign: 'center'
+				},
+				// Recipient name (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 360,
+					width: 1680,
+					text: 'Recipient Name',
+					fontSize: 80,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#111827',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'recipientName',
+							property: 'text',
+							description: 'Name of the certificate recipient'
+						}
+					]
+				},
+				// Achievement text (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 300,
+					top: 490,
+					width: 1320,
+					text: 'for successfully completing the Advanced JavaScript Course',
+					fontSize: 20,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#6b7280',
+					textAlign: 'center',
+					lineHeight: 1.6,
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'achievementText',
+							property: 'text',
+							description: 'Description of the achievement'
+						}
+					]
+				},
+				// Organization name (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 590,
+					width: 1680,
+					text: 'Your Organization Name',
+					fontSize: 24,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#374151',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'organizationName',
+							property: 'text',
+							description: 'Name of the organization'
+						}
+					]
+				},
+				// Date (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 120,
+					top: 650,
+					width: 1680,
+					text: 'December 14, 2024',
+					fontSize: 16,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#9ca3af',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'date',
+							property: 'text',
+							description: 'Date of certificate issuance'
+						}
+					]
+				},
+				// Signature line 1
+				{
+					type: 'line',
+					id: generateId(),
+					left: 400,
+					top: 860,
+					x1: 0,
+					y1: 0,
+					x2: 280,
+					y2: 0,
+					stroke: '#d1d5db',
+					strokeWidth: 1
+				},
+				// Signature label 1
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 400,
+					top: 872,
+					width: 280,
+					text: 'Instructor',
+					fontSize: 12,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#9ca3af',
+					textAlign: 'center'
+				},
+				// Signature line 2
+				{
+					type: 'line',
+					id: generateId(),
+					left: 1240,
+					top: 860,
+					x1: 0,
+					y1: 0,
+					x2: 280,
+					y2: 0,
+					stroke: '#d1d5db',
+					strokeWidth: 1
+				},
+				// Signature label 2
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 1240,
+					top: 872,
+					width: 280,
+					text: 'Director',
+					fontSize: 12,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#9ca3af',
+					textAlign: 'center'
+				}
+			],
+			background: '#ffffff'
+		}
+	};
+}
+
+/**
+ * Template 5: Creative
+ * White background with coral/red accent (#ff6b6b), bold colored rectangle as side accent,
+ * playful but professional, Inter font, shadow effects via overlapping colored rectangles.
+ */
+function getCreativeTemplate() {
+	return {
+		id: 'creative',
+		name: 'Creative',
+		description: 'Bold and colorful design with coral accents and playful geometric elements',
+		thumbnailColor: '#ff6b6b',
+		width: 1920,
+		height: 1080,
+		fabricJSData: {
+			version: '6.0.0',
+			objects: [
+				// White background
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 0,
+					width: 1920,
+					height: 1080,
+					fill: '#ffffff',
+					selectable: false,
+					evented: false
+				},
+				// Left accent bar
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 0,
+					top: 0,
+					width: 80,
+					height: 1080,
+					fill: '#ff6b6b'
+				},
+				// Shadow rectangle behind main content area
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 134,
+					top: 54,
+					width: 1720,
+					height: 976,
+					fill: '#ffe0e0',
+					rx: 12,
+					ry: 12
+				},
+				// Main content area
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 126,
+					top: 46,
+					width: 1720,
+					height: 976,
+					fill: '#ffffff',
+					stroke: '#ff6b6b',
+					strokeWidth: 3,
+					rx: 12,
+					ry: 12
+				},
+				// Top-right decorative circle (large)
+				{
+					type: 'circle',
+					id: generateId(),
+					left: 1620,
+					top: 60,
+					radius: 100,
+					fill: '#fff0f0',
+					stroke: '#ff6b6b',
+					strokeWidth: 2,
+					opacity: 0.5
+				},
+				// Top-right decorative circle (small)
+				{
+					type: 'circle',
+					id: generateId(),
+					left: 1700,
+					top: 140,
+					radius: 40,
+					fill: '#ff6b6b',
+					opacity: 0.15
+				},
+				// Bottom-left decorative circle
+				{
+					type: 'circle',
+					id: generateId(),
+					left: 140,
+					top: 880,
+					radius: 60,
+					fill: '#ff6b6b',
+					opacity: 0.1
+				},
+				// Small accent dot
+				{
+					type: 'circle',
+					id: generateId(),
+					left: 940,
+					top: 120,
+					radius: 6,
+					fill: '#ff6b6b'
+				},
+				// Certificate label
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 130,
+					width: 1560,
+					text: 'CERTIFICATE OF ACHIEVEMENT',
+					fontSize: 18,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#ff6b6b',
+					textAlign: 'center',
+					letterSpacing: 600
+				},
+				// Decorative line under title
+				{
+					type: 'line',
+					id: generateId(),
+					left: 760,
+					top: 175,
+					x1: 0,
+					y1: 0,
+					x2: 400,
+					y2: 0,
+					stroke: '#ff6b6b',
+					strokeWidth: 3
+				},
+				// "Proudly awarded to" text
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 210,
+					width: 1560,
+					text: 'Proudly awarded to',
+					fontSize: 18,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#888888',
+					textAlign: 'center'
+				},
+				// Recipient name (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 270,
+					width: 1560,
+					text: 'Recipient Name',
+					fontSize: 76,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#2d2d2d',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'recipientName',
+							property: 'text',
+							description: 'Name of the certificate recipient'
+						}
+					]
+				},
+				// Accent underline for name
+				{
+					type: 'rect',
+					id: generateId(),
+					left: 600,
+					top: 380,
+					width: 720,
+					height: 6,
+					fill: '#ff6b6b',
+					rx: 3,
+					ry: 3
+				},
+				// Achievement text (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 260,
+					top: 420,
+					width: 1440,
+					text: 'for successfully completing the Advanced JavaScript Course',
+					fontSize: 22,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#666666',
+					textAlign: 'center',
+					lineHeight: 1.5,
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'achievementText',
+							property: 'text',
+							description: 'Description of the achievement'
+						}
+					]
+				},
+				// "Issued by" label
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 520,
+					width: 1560,
+					text: 'Issued by',
+					fontSize: 14,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#aaaaaa',
+					textAlign: 'center'
+				},
+				// Organization name (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 550,
+					width: 1560,
+					text: 'Your Organization Name',
+					fontSize: 34,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#ff6b6b',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'organizationName',
+							property: 'text',
+							description: 'Name of the organization'
+						}
+					]
+				},
+				// Date label
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 640,
+					width: 1560,
+					text: 'Date',
+					fontSize: 12,
+					fontWeight: 'bold',
+					fontFamily: 'Inter',
+					fill: '#cccccc',
+					textAlign: 'center',
+					letterSpacing: 300
+				},
+				// Date (variable)
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 200,
+					top: 665,
+					width: 1560,
+					text: 'December 14, 2024',
+					fontSize: 22,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#2d2d2d',
+					textAlign: 'center',
+					isVariable: true,
+					variableBindings: [
+						{
+							variableName: 'date',
+							property: 'text',
+							description: 'Date of certificate issuance'
+						}
+					]
+				},
+				// Signature line 1
+				{
+					type: 'line',
+					id: generateId(),
+					left: 340,
+					top: 870,
+					x1: 0,
+					y1: 0,
+					x2: 300,
+					y2: 0,
+					stroke: '#ff6b6b',
+					strokeWidth: 2
+				},
+				// Signature label 1
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 340,
+					top: 882,
+					width: 300,
+					text: 'Instructor',
+					fontSize: 13,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#999999',
+					textAlign: 'center'
+				},
+				// Signature line 2
+				{
+					type: 'line',
+					id: generateId(),
+					left: 1280,
+					top: 870,
+					x1: 0,
+					y1: 0,
+					x2: 300,
+					y2: 0,
+					stroke: '#ff6b6b',
+					strokeWidth: 2
+				},
+				// Signature label 2
+				{
+					type: 'textbox',
+					id: generateId(),
+					left: 1280,
+					top: 882,
+					width: 300,
+					text: 'Director',
+					fontSize: 13,
+					fontWeight: 'normal',
+					fontFamily: 'Inter',
+					fill: '#999999',
+					textAlign: 'center'
+				}
+			],
+			background: '#ffffff'
+		}
+	};
+}
+
+export const certificateTemplates = [
+	getElegantTemplate(),
+	getModernDarkTemplate(),
+	getCorporateTemplate(),
+	getMinimalistTemplate(),
+	getCreativeTemplate()
+];

--- a/src/lib/components/tools/MiniEditor.svelte
+++ b/src/lib/components/tools/MiniEditor.svelte
@@ -11,6 +11,7 @@
 	let selectedText = null;
 	let canvasReady = false;
 	let loading = false;
+	let loadError = false;
 	let loadGeneration = 0;
 	let lastLoadedData = null; // Track what we've already loaded to prevent re-render loop
 
@@ -33,6 +34,7 @@
 		const thisGeneration = ++loadGeneration;
 		loading = true;
 		canvasReady = false;
+		loadError = false;
 
 		// Dispose previous canvas if exists
 		if (fabricCanvas) {
@@ -99,7 +101,7 @@
 				selectedText = null;
 			});
 		} catch (err) {
-			// Silent fail — canvas preview is non-critical
+			loadError = true;
 		} finally {
 			loading = false;
 		}
@@ -114,10 +116,51 @@
 		if (!fabricCanvas) return null;
 		return fabricCanvas.toJSON();
 	}
+
+	export function setVariableValue(variableName, value) {
+		if (!fabricCanvas) return;
+		fabricCanvas.getObjects().forEach((obj) => {
+			const bindings = obj.variableBindings;
+			if (!bindings || !Array.isArray(bindings)) return;
+			for (const binding of bindings) {
+				if (binding.variableName === variableName) {
+					obj.set('text', value);
+					break;
+				}
+			}
+		});
+		fabricCanvas.renderAll();
+	}
+
+	export function getVariables() {
+		if (!fabricCanvas) return [];
+		const variables = [];
+		fabricCanvas.getObjects().forEach((obj) => {
+			const bindings = obj.variableBindings;
+			if (!bindings || !Array.isArray(bindings) || bindings.length === 0) return;
+			for (const binding of bindings) {
+				variables.push({
+					name: binding.variableName,
+					value: obj.text,
+					description: binding.description
+				});
+			}
+		});
+		return variables;
+	}
 </script>
 
 <div class="relative">
-	{#if loading}
+	{#if loadError}
+		<div
+			class="absolute inset-0 z-20 flex items-center justify-center bg-gray-50 border-[3px] border-gray-900 shadow-[6px_6px_0_0_#1f2937]"
+		>
+			<div class="flex flex-col items-center gap-2 text-center px-4">
+				<span class="text-lg font-bold text-gray-900">Failed to load editor</span>
+				<span class="text-sm text-gray-500">The template could not be rendered. Please try selecting another template.</span>
+			</div>
+		</div>
+	{:else if loading}
 		<div
 			class="absolute inset-0 z-20 flex items-center justify-center bg-gray-50 border-[3px] border-gray-900 shadow-[6px_6px_0_0_#1f2937]"
 		>

--- a/src/lib/components/tools/MiniEditor.svelte
+++ b/src/lib/components/tools/MiniEditor.svelte
@@ -132,6 +132,20 @@
 		fabricCanvas.renderAll();
 	}
 
+	export function setVariableValues(map) {
+		if (!fabricCanvas || !map) return;
+		fabricCanvas.getObjects().forEach((obj) => {
+			const bindings = obj.variableBindings;
+			if (!bindings || !Array.isArray(bindings)) return;
+			for (const binding of bindings) {
+				if (binding.variableName in map) {
+					obj.set('text', map[binding.variableName]);
+				}
+			}
+		});
+		fabricCanvas.renderAll();
+	}
+
 	export function getVariables() {
 		if (!fabricCanvas) return [];
 		const variables = [];

--- a/src/lib/pseo/use-cases.js
+++ b/src/lib/pseo/use-cases.js
@@ -533,6 +533,7 @@ export const useCaseDetails = {
 	},
 	certificate: {
 		label: 'Certificate Generator',
+		toolUrl: '/tools/certificate-generator',
 		description: 'Generate personalized certificates and diplomas as downloadable images for events, courses, and recognition programs.',
 		seoKeywords: [
 			'certificate generator',

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -91,6 +91,12 @@
 			icon: 'fa-solid fa-file-invoice-dollar'
 		},
 		{
+			name: 'Certificate Generator',
+			description: 'Create professional certificates with 5 beautiful templates. Customize and download for free.',
+			url: '/tools/certificate-generator',
+			icon: 'fa-solid fa-certificate'
+		},
+		{
 			name: 'URL to Image',
 			description: 'Generate images from any URL with our free online tool.',
 			url: '/tools/url-to-image-generator',

--- a/src/routes/tools/certificate-generator/+page.svelte
+++ b/src/routes/tools/certificate-generator/+page.svelte
@@ -5,7 +5,7 @@
 	import GenerationLimitBanner from '$lib/components/tools/GenerationLimitBanner.svelte';
 	import MiniEditor from '$lib/components/tools/MiniEditor.svelte';
 	import RelatedTools from '$lib/components/tools/RelatedTools.svelte';
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { user } from '../../../store/user.store';
 	import { toast } from '../../../store/toast.store';
 	import { generationLimits } from '../../../store/generationLimits.store';
@@ -15,11 +15,8 @@
 	import { analytics } from '$lib/analytics.js';
 	import { certificateTemplates } from '$lib/components/tools/CertificateTemplates.js';
 
-	// User login state
-	let isUserLoggedIn = false;
-	user.subscribe((userData) => {
-		isUserLoggedIn = !!userData?.email;
-	});
+	// User login state (reactive — no manual subscribe needed)
+	$: isUserLoggedIn = !!$user?.email;
 
 	let selectedTemplate = certificateTemplates[0];
 	let formValues = {
@@ -33,18 +30,25 @@
 	let generatedImageUrl = '';
 	let generationError = '';
 	let miniEditorRef;
+	let lastEditedData = null;
 
-	// Debounced form-to-canvas sync
+	// Debounced form-to-canvas sync (single renderAll via setVariableValues)
 	let debounceTimer;
 	$: if (miniEditorRef && formValues) {
 		clearTimeout(debounceTimer);
 		debounceTimer = setTimeout(() => {
-			miniEditorRef.setVariableValue?.('recipientName', formValues.recipientName);
-			miniEditorRef.setVariableValue?.('organizationName', formValues.organizationName);
-			miniEditorRef.setVariableValue?.('date', formValues.date);
-			miniEditorRef.setVariableValue?.('achievementText', formValues.achievementText);
+			miniEditorRef.setVariableValues?.({
+				recipientName: formValues.recipientName,
+				organizationName: formValues.organizationName,
+				date: formValues.date,
+				achievementText: formValues.achievementText
+			});
 		}, 150);
 	}
+
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
 
 	function selectTemplate(template) {
 		selectedTemplate = template;
@@ -56,6 +60,7 @@
 		};
 		generatedImageUrl = '';
 		generationError = '';
+		lastEditedData = null;
 	}
 
 	// Generation flow (matches [usecase] page pattern)
@@ -82,6 +87,7 @@
 
 			if (response?.url) {
 				generatedImageUrl = response.url;
+				lastEditedData = editedData;
 				toast.set({ message: 'Certificate generated successfully!', type: 'success', duration: 2000 });
 				analytics.trackImageGenerated({
 					tool_name: 'certificate_generator',
@@ -127,22 +133,23 @@
 		}
 	}
 
-	// NextSteps template draft
+	// NextSteps template draft — uses the edited canvas state captured on generation
+	$: currentFabricData = lastEditedData || selectedTemplate.fabricJSData;
 	$: templateDraft = {
 		version: 1,
 		name: 'Certificate template',
 		type: 'certificate',
 		width: selectedTemplate.width,
 		height: selectedTemplate.height,
-		fabricJSData: miniEditorRef?.getEditedFabricData?.() || selectedTemplate.fabricJSData,
+		fabricJSData: currentFabricData,
 		source: 'certificate-generator'
 	};
 
-	// API snippet for NextSteps
+	// API snippet for NextSteps — reflects the actual data that was rendered
 	$: apiSnippet = `curl -X POST https://api.pictify.io/image/canvas \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
-  -d '${JSON.stringify({ fabricJSData: selectedTemplate.fabricJSData, width: selectedTemplate.width, height: selectedTemplate.height }, null, 2)}'`;
+  -d '${JSON.stringify({ fabricJSData: currentFabricData, width: selectedTemplate.width, height: selectedTemplate.height }, null, 2)}'`;
 
 	// FAQ data
 	const faqs = [

--- a/src/routes/tools/certificate-generator/+page.svelte
+++ b/src/routes/tools/certificate-generator/+page.svelte
@@ -1,0 +1,926 @@
+<script>
+	import Nav from '$lib/components/landingPage/Nav.svelte';
+	import Footer from '$lib/components/landingPage/Footer.svelte';
+	import NextSteps from '$lib/components/tools/NextSteps.svelte';
+	import GenerationLimitBanner from '$lib/components/tools/GenerationLimitBanner.svelte';
+	import MiniEditor from '$lib/components/tools/MiniEditor.svelte';
+	import RelatedTools from '$lib/components/tools/RelatedTools.svelte';
+	import { onMount } from 'svelte';
+	import { user } from '../../../store/user.store';
+	import { toast } from '../../../store/toast.store';
+	import { generationLimits } from '../../../store/generationLimits.store';
+	import { pageActions } from '../../../store/pages.store';
+	import { goto } from '$app/navigation';
+	import backend from '../../../service/backend';
+	import { analytics } from '$lib/analytics.js';
+	import { certificateTemplates } from '$lib/components/tools/CertificateTemplates.js';
+
+	// User login state
+	let isUserLoggedIn = false;
+	user.subscribe((userData) => {
+		isUserLoggedIn = !!userData?.email;
+	});
+
+	let selectedTemplate = certificateTemplates[0];
+	let formValues = {
+		recipientName: 'John Doe',
+		organizationName: 'Your Organization',
+		date: new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
+		achievementText: 'for successfully completing the Advanced Training Program'
+	};
+
+	let isGenerating = false;
+	let generatedImageUrl = '';
+	let generationError = '';
+	let miniEditorRef;
+
+	// Debounced form-to-canvas sync
+	let debounceTimer;
+	$: if (miniEditorRef && formValues) {
+		clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(() => {
+			miniEditorRef.setVariableValue?.('recipientName', formValues.recipientName);
+			miniEditorRef.setVariableValue?.('organizationName', formValues.organizationName);
+			miniEditorRef.setVariableValue?.('date', formValues.date);
+			miniEditorRef.setVariableValue?.('achievementText', formValues.achievementText);
+		}, 150);
+	}
+
+	function selectTemplate(template) {
+		selectedTemplate = template;
+		formValues = {
+			recipientName: 'John Doe',
+			organizationName: 'Your Organization',
+			date: new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
+			achievementText: 'for successfully completing the Advanced Training Program'
+		};
+		generatedImageUrl = '';
+		generationError = '';
+	}
+
+	// Generation flow (matches [usecase] page pattern)
+	async function handleGenerate() {
+		const editedData = miniEditorRef?.getEditedFabricData?.() || selectedTemplate.fabricJSData;
+		if (!editedData) {
+			toast.set({ message: 'No template data available', type: 'error', duration: 2000 });
+			return;
+		}
+
+		generationLimits.increment();
+		isGenerating = true;
+		generationError = '';
+		generatedImageUrl = '';
+
+		try {
+			const response = await backend.post('/image/public/canvas', {
+				fabricJSData: editedData,
+				width: selectedTemplate.width,
+				height: selectedTemplate.height,
+				fileExtension: 'png',
+				watermark: !isUserLoggedIn
+			});
+
+			if (response?.url) {
+				generatedImageUrl = response.url;
+				toast.set({ message: 'Certificate generated successfully!', type: 'success', duration: 2000 });
+				analytics.trackImageGenerated({
+					tool_name: 'certificate_generator',
+					format: 'png',
+					with_watermark: !isUserLoggedIn
+				});
+			} else {
+				throw new Error('No image URL in response');
+			}
+		} catch (e) {
+			if (e.message?.includes('rate') || e.status === 429) {
+				generationError = 'Too many requests. Please wait a moment and try again.';
+			} else {
+				generationError = e.message || 'Failed to generate certificate';
+			}
+			toast.set({ message: generationError, type: 'error', duration: 3000 });
+		} finally {
+			isGenerating = false;
+		}
+	}
+
+	// Open in full canvas editor (matches [usecase] page pattern)
+	function openInCanvasEditor() {
+		const template = {
+			...selectedTemplate,
+			name: `${selectedTemplate.name} Certificate`,
+			outputFormat: 'image'
+		};
+
+		pageActions.initFromTemplate(template);
+
+		try {
+			const DRAFT_KEY = 'pictify_template_draft_v1';
+			localStorage.setItem(DRAFT_KEY, JSON.stringify(template));
+		} catch (e) {
+			/* ignored */
+		}
+
+		if ($user?.email) {
+			goto('/template-workspace/image/create');
+		} else {
+			goto('/canvas/try?usecase=certificate');
+		}
+	}
+
+	// NextSteps template draft
+	$: templateDraft = {
+		version: 1,
+		name: 'Certificate template',
+		type: 'certificate',
+		width: selectedTemplate.width,
+		height: selectedTemplate.height,
+		fabricJSData: miniEditorRef?.getEditedFabricData?.() || selectedTemplate.fabricJSData,
+		source: 'certificate-generator'
+	};
+
+	// API snippet for NextSteps
+	$: apiSnippet = `curl -X POST https://api.pictify.io/image/canvas \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -d '${JSON.stringify({ fabricJSData: selectedTemplate.fabricJSData, width: selectedTemplate.width, height: selectedTemplate.height }, null, 2)}'`;
+
+	// FAQ data
+	const faqs = [
+		{
+			q: 'Is this certificate generator really free?',
+			a: 'Yes, you can generate unlimited certificates for free. Logged-in users get watermark-free downloads, while guests receive a small Pictify watermark. Sign up for a free account to remove it.'
+		},
+		{
+			q: 'Can I customize the certificate design?',
+			a: 'Yes, you can edit any text directly on the canvas preview by clicking on it. Use the form fields to update recipient name, organization, date, and achievement text. For full design control, open the certificate in our full editor.'
+		},
+		{
+			q: 'What formats can I download certificates in?',
+			a: 'Currently certificates are generated as high-quality PNG images at 1920x1080 resolution. PDF support is coming soon. You can also use our API to generate certificates in JPG and WebP formats.'
+		},
+		{
+			q: 'Can I generate certificates in bulk?',
+			a: 'Yes! Use our API to batch generate certificates programmatically. Pass different recipient names, dates, and achievement text for each request. Perfect for course completions, event attendance, and employee recognition programs.'
+		},
+		{
+			q: 'Can I add my company logo?',
+			a: 'Open the certificate in our full editor to add logos, custom images, shapes, and additional text elements. The full editor gives you complete design control over every element.'
+		},
+		{
+			q: 'Are the generated certificates printable?',
+			a: 'Yes, certificates are generated at 1920x1080 pixels which provides excellent print quality for standard certificate sizes. For best results, print on high-quality paper or card stock.'
+		}
+	];
+
+	// Structured data
+	const structuredDataJson = JSON.stringify({
+		'@context': 'https://schema.org',
+		'@type': 'WebApplication',
+		name: 'Pictify.io Certificate Generator',
+		url: 'https://pictify.io/tools/certificate-generator',
+		description:
+			'Create professional certificates for free with Pictify\'s interactive certificate generator. Choose from 5 beautiful templates, customize recipient names, dates, and achievements, and download as PNG.',
+		applicationCategory: ['DesignApplication', 'ImageGenerator'],
+		operatingSystem: 'Web',
+		offers: {
+			'@type': 'Offer',
+			price: '0',
+			priceCurrency: 'USD',
+			availability: 'https://schema.org/InStock'
+		},
+		featureList: [
+			'5 professional certificate templates',
+			'Real-time canvas preview',
+			'Customizable text fields',
+			'High-resolution PNG download',
+			'API for bulk generation',
+			'No signup required'
+		],
+		creator: {
+			'@type': 'Organization',
+			name: 'Pictify.io',
+			url: 'https://pictify.io'
+		}
+	});
+
+	const faqSchemaJson = JSON.stringify({
+		'@context': 'https://schema.org',
+		'@type': 'FAQPage',
+		mainEntity: faqs.map((faq) => ({
+			'@type': 'Question',
+			name: faq.q,
+			acceptedAnswer: {
+				'@type': 'Answer',
+				text: faq.a
+			}
+		}))
+	});
+
+	const breadcrumbSchemaJson = JSON.stringify({
+		'@context': 'https://schema.org',
+		'@type': 'BreadcrumbList',
+		itemListElement: [
+			{ '@type': 'ListItem', position: 1, name: 'Home', item: 'https://pictify.io/' },
+			{ '@type': 'ListItem', position: 2, name: 'Tools', item: 'https://pictify.io/tools' },
+			{ '@type': 'ListItem', position: 3, name: 'Certificate Generator' }
+		]
+	});
+
+	onMount(() => {
+		analytics.trackToolOpened({ tool_name: 'certificate_generator' });
+	});
+</script>
+
+<svelte:head>
+	<title>Free Certificate Generator Online | Create Custom Certificates | Pictify.io</title>
+	<meta
+		name="description"
+		content="Create professional certificates for free with Pictify's interactive certificate generator. Choose from 5 beautiful templates, customize recipient names, dates, and achievements, and download as PNG."
+	/>
+	<meta
+		name="keywords"
+		content="certificate generator, free certificate maker, online certificate creator, custom certificates, certificate template, printable certificates, Pictify"
+	/>
+	<link rel="canonical" href="https://pictify.io/tools/certificate-generator" />
+
+	<!-- Open Graph -->
+	<meta
+		property="og:title"
+		content="Free Certificate Generator Online | Create Custom Certificates | Pictify.io"
+	/>
+	<meta
+		property="og:description"
+		content="Create professional certificates for free. Choose from 5 beautiful templates, customize text, and download as high-resolution PNG."
+	/>
+	<meta property="og:url" content="https://pictify.io/tools/certificate-generator" />
+	<meta property="og:type" content="website" />
+	<meta property="og:image" content="https://media.pictify.io/qyl7z-1775406830860.png" />
+
+	<!-- Twitter Card -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:site" content="@pictify_io" />
+	<meta
+		name="twitter:title"
+		content="Free Certificate Generator Online | Pictify.io"
+	/>
+	<meta
+		name="twitter:description"
+		content="Create professional certificates for free. Choose from 5 beautiful templates, customize text, and download as high-resolution PNG."
+	/>
+	<meta name="twitter:image" content="https://media.pictify.io/qyl7z-1775406830860.png" />
+
+	{@html `<script type="application/ld+json">${structuredDataJson}</script>`}
+	{@html `<script type="application/ld+json">${faqSchemaJson}</script>`}
+	{@html `<script type="application/ld+json">${breadcrumbSchemaJson}</script>`}
+</svelte:head>
+
+<section class="w-full min-h-screen bg-[#FFFDF8] relative overflow-x-hidden font-['Manrope']">
+	<Nav />
+
+	<!-- Background Elements -->
+	<div
+		class="absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:20px_20px] opacity-70 pointer-events-none"
+	/>
+	<div
+		class="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[800px] bg-[#ffc480]/10 rounded-full blur-[100px] -z-10 pointer-events-none"
+	/>
+	<div
+		class="absolute bottom-0 right-0 w-[500px] h-[500px] bg-[#ff6b6b]/5 rounded-full blur-[80px] -z-10 pointer-events-none"
+	/>
+
+	<main
+		class="w-full max-w-7xl mx-auto px-4 sm:px-6 pt-8 sm:pt-12 pb-16 md:pt-24 md:pb-32 relative z-10"
+	>
+		<!-- Breadcrumb -->
+		<nav class="mb-12 flex justify-center">
+			<ol
+				class="inline-flex items-center gap-2 text-sm font-bold bg-white px-4 py-2 border-[3px] border-gray-900 rounded-full shadow-[4px_4px_0_0_#1f2937]"
+			>
+				<li><a href="/" class="text-gray-500 hover:text-gray-900 transition-colors">Home</a></li>
+				<li class="text-gray-300">/</li>
+				<li>
+					<a href="/tools" class="text-gray-500 hover:text-gray-900 transition-colors">Tools</a>
+				</li>
+				<li class="text-gray-300">/</li>
+				<li class="text-gray-900">Certificate Generator</li>
+			</ol>
+		</nav>
+
+		<!-- Hero Section -->
+		<div
+			class="relative flex flex-col items-center justify-center text-center mb-8 sm:mb-12 lg:mb-16 pt-4 sm:pt-10"
+		>
+			<!-- Badge -->
+			<div
+				class="inline-flex transform -rotate-2 hover:rotate-0 transition-transform duration-300 cursor-default mb-4 sm:mb-8"
+			>
+				<div
+					class="px-4 sm:px-6 py-1.5 sm:py-2 bg-[#ffc480] border-[3px] sm:border-[4px] border-black text-black font-black text-xs sm:text-sm md:text-base uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] sm:shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:translate-x-[2px] hover:translate-y-[2px] transition-all"
+				>
+					Free Tool
+				</div>
+			</div>
+
+			<!-- Main Title -->
+			<h1
+				class="relative z-10 text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-black text-gray-900 tracking-tighter leading-tight mb-4 sm:mb-8"
+			>
+				<span class="block sm:inline">CERTIFICATE</span>
+				<span class="relative inline-block text-white mt-1 sm:mt-2 md:mt-0 md:ml-3">
+					<span class="relative z-10 px-2 sm:px-3 md:px-4">GENERATOR</span>
+					<span
+						class="absolute inset-0 bg-[#ff6b6b] transform -skew-x-3 border-[3px] sm:border-[4px] border-black shadow-[4px_4px_0_0_#000] sm:shadow-[6px_6px_0_0_#000] -z-0"
+					/>
+				</span>
+			</h1>
+
+			<!-- Description -->
+			<div class="max-w-2xl mx-auto px-2">
+				<p
+					class="text-base sm:text-lg md:text-xl text-gray-800 font-bold leading-relaxed border-[3px] border-black bg-white p-4 sm:p-6 shadow-[4px_4px_0_0_#e5e7eb] sm:shadow-[8px_8px_0_0_#e5e7eb]"
+				>
+					Create <span class="bg-[#ffc480] px-1 border-b-[2px] sm:border-b-[3px] border-black"
+						>professional certificates</span
+					>
+					in seconds.
+					<span class="text-gray-500 text-sm sm:text-base mt-2 sm:mt-3 block font-semibold"
+						>5 beautiful templates with real-time preview and instant download</span
+					>
+				</p>
+			</div>
+		</div>
+
+		<!-- Generation Limit Banner -->
+		<GenerationLimitBanner toolName="certificate_generator" />
+
+		<!-- Template Gallery -->
+		<div class="max-w-5xl mx-auto mb-10 sm:mb-14">
+			<h2 class="text-xl sm:text-2xl font-black mb-6 flex items-center gap-3">
+				<span
+					class="w-8 h-8 bg-[#ffc480] border-[3px] border-black flex items-center justify-center shadow-[2px_2px_0_0_#000]"
+				>
+					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+						><path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
+						/></svg
+					>
+				</span>
+				CHOOSE A TEMPLATE
+			</h2>
+
+			<div class="flex gap-4 overflow-x-auto pb-4 scrollbar-thin">
+				{#each certificateTemplates as template}
+					<button
+						class="flex-shrink-0 w-44 bg-white border-[3px] {selectedTemplate.id === template.id
+							? 'border-[#ff6b6b] shadow-[6px_6px_0_0_#ff6b6b]'
+							: 'border-black shadow-[4px_4px_0_0_#000]'} p-3 overflow-hidden hover:shadow-[2px_2px_0_0_#000] hover:translate-x-[2px] hover:translate-y-[2px] transition-all cursor-pointer rounded-xl relative"
+						on:click={() => selectTemplate(template)}
+					>
+						{#if selectedTemplate.id === template.id}
+							<div
+								class="absolute top-2 right-2 z-10 w-6 h-6 bg-[#ff6b6b] border-[2px] border-black flex items-center justify-center rounded-full"
+							>
+								<span class="text-white font-black text-sm">&#10003;</span>
+							</div>
+						{/if}
+						<div
+							class="w-full h-20 rounded-lg mb-2 border-[2px] border-gray-200"
+							style="background-color: {template.thumbnailColor};"
+						/>
+						<span class="text-xs font-black text-gray-900 uppercase tracking-wide block text-center"
+							>{template.name}</span
+						>
+						<span class="text-[10px] text-gray-500 font-medium block text-center mt-0.5 line-clamp-1"
+							>{template.description}</span
+						>
+					</button>
+				{/each}
+			</div>
+		</div>
+
+		<!-- Main Editor Stack -->
+		<div class="max-w-4xl mx-auto flex flex-col gap-6 sm:gap-8 items-stretch mb-10">
+			<!-- Left Column: Form -->
+			<div
+				class="bg-white border-[3px] border-black shadow-[6px_6px_0_0_#000] sm:shadow-[8px_8px_0_0_#000] overflow-hidden rounded-xl"
+			>
+				<!-- Terminal Header -->
+				<div
+					class="bg-black text-white px-4 py-3 flex justify-between items-center border-b-[3px] border-black"
+				>
+					<h2 class="font-bold font-mono tracking-widest text-xs uppercase flex items-center gap-2">
+						<span class="animate-pulse">_</span> CERTIFICATE DETAILS
+					</h2>
+					<div class="flex gap-2">
+						<div class="w-3 h-3 bg-[#ff6b6b] border border-black" />
+						<div class="w-3 h-3 bg-[#ffc480] border border-black" />
+						<div class="w-3 h-3 bg-[#4ade80] border border-black" />
+					</div>
+				</div>
+
+				<div class="p-4 sm:p-6 space-y-5">
+					<!-- Recipient Name -->
+					<div class="space-y-2">
+						<h3
+							class="text-xs font-black text-black uppercase tracking-wider flex items-center gap-2"
+						>
+							<span
+								class="w-6 h-6 bg-[#ffc480] border-[2px] border-black flex items-center justify-center text-xs"
+								>1</span
+							>
+							Recipient Name
+						</h3>
+						<input
+							bind:value={formValues.recipientName}
+							type="text"
+							class="w-full border-[3px] border-black p-3 font-bold text-sm shadow-[3px_3px_0_0_#000] focus:shadow-[1px_1px_0_0_#000] focus:translate-x-[2px] focus:translate-y-[2px] transition-all outline-none rounded-lg"
+							placeholder="John Doe"
+						/>
+					</div>
+
+					<!-- Organization Name -->
+					<div class="space-y-2">
+						<h3
+							class="text-xs font-black text-black uppercase tracking-wider flex items-center gap-2"
+						>
+							<span
+								class="w-6 h-6 bg-[#60a5fa] border-[2px] border-black flex items-center justify-center text-xs text-white"
+								>2</span
+							>
+							Organization Name
+						</h3>
+						<input
+							bind:value={formValues.organizationName}
+							type="text"
+							class="w-full border-[3px] border-black p-3 font-bold text-sm shadow-[3px_3px_0_0_#000] focus:shadow-[1px_1px_0_0_#000] focus:translate-x-[2px] focus:translate-y-[2px] transition-all outline-none rounded-lg"
+							placeholder="Your Organization"
+						/>
+					</div>
+
+					<!-- Date -->
+					<div class="space-y-2">
+						<h3
+							class="text-xs font-black text-black uppercase tracking-wider flex items-center gap-2"
+						>
+							<span
+								class="w-6 h-6 bg-[#a78bfa] border-[2px] border-black flex items-center justify-center text-xs text-white"
+								>3</span
+							>
+							Date
+						</h3>
+						<input
+							bind:value={formValues.date}
+							type="text"
+							class="w-full border-[3px] border-black p-3 font-bold text-sm shadow-[3px_3px_0_0_#000] focus:shadow-[1px_1px_0_0_#000] focus:translate-x-[2px] focus:translate-y-[2px] transition-all outline-none rounded-lg"
+							placeholder="April 13, 2026"
+						/>
+					</div>
+
+					<!-- Achievement Text -->
+					<div class="space-y-2">
+						<h3
+							class="text-xs font-black text-black uppercase tracking-wider flex items-center gap-2"
+						>
+							<span
+								class="w-6 h-6 bg-[#ff6b6b] border-[2px] border-black flex items-center justify-center text-xs text-white"
+								>4</span
+							>
+							Achievement
+						</h3>
+						<textarea
+							bind:value={formValues.achievementText}
+							class="w-full border-[3px] border-black p-3 font-bold text-sm shadow-[3px_3px_0_0_#000] focus:shadow-[1px_1px_0_0_#000] focus:translate-x-[2px] focus:translate-y-[2px] transition-all outline-none resize-none rounded-lg"
+							placeholder="for successfully completing the Advanced Training Program"
+							rows="3"
+						/>
+					</div>
+
+					<!-- Open Editor Button -->
+					<button
+						type="button"
+						on:click={openInCanvasEditor}
+						class="w-full py-3 bg-[#4ade80] text-gray-900 border-[3px] border-gray-900 font-black text-sm uppercase tracking-wide shadow-[4px_4px_0_0_#1f2937] hover:shadow-[2px_2px_0_0_#1f2937] hover:translate-x-[2px] hover:translate-y-[2px] transition-all flex items-center justify-center gap-2 rounded-xl"
+					>
+						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+							><path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+							/></svg
+						>
+						Open Full Editor
+					</button>
+				</div>
+			</div>
+
+			<!-- Right Column: Canvas Preview -->
+			<div class="space-y-4 sm:space-y-6">
+				<div
+					class="bg-white border-[3px] border-black shadow-[6px_6px_0_0_#000] sm:shadow-[8px_8px_0_0_#000] overflow-hidden rounded-xl"
+				>
+					<!-- Preview Header -->
+					<div
+						class="bg-gray-50 border-b-[3px] border-gray-900 p-4 flex items-center justify-between"
+					>
+						<div class="flex items-center gap-2">
+							<div class="w-3.5 h-3.5 rounded-full bg-[#ff6b6b] border-2 border-gray-900" />
+							<div class="w-3.5 h-3.5 rounded-full bg-[#ffc480] border-2 border-gray-900" />
+							<div class="w-3.5 h-3.5 rounded-full bg-[#4ade80] border-2 border-gray-900" />
+						</div>
+						<div
+							class="font-mono text-xs font-bold text-gray-500 uppercase flex items-center gap-2"
+						>
+							<span class="px-2 py-0.5 bg-[#4ade80]/20 border border-[#4ade80] rounded text-gray-700">Interactive Editor</span>
+							{selectedTemplate.width} x {selectedTemplate.height}px
+						</div>
+					</div>
+
+					<!-- Interactive Mini-Editor Preview -->
+					<div
+						class="p-4 sm:p-6 bg-gray-100 flex flex-col items-center justify-center relative min-h-[300px]"
+					>
+						<div
+							class="absolute inset-0 opacity-10"
+							style="background-image: radial-gradient(#000 1px, transparent 1px); background-size: 20px 20px;"
+						/>
+
+						<div class="relative z-10 flex flex-col items-center w-full max-w-[640px] mx-auto">
+							{#if selectedTemplate?.fabricJSData}
+								<MiniEditor
+									bind:this={miniEditorRef}
+									fabricJSData={selectedTemplate.fabricJSData}
+									width={selectedTemplate.width}
+									height={selectedTemplate.height}
+								/>
+							{:else}
+								<div class="w-full h-[315px] flex items-center justify-center bg-gray-50 border-[3px] border-gray-900 shadow-[6px_6px_0_0_#1f2937]">
+									<p class="font-bold text-gray-400">Preview not available</p>
+								</div>
+							{/if}
+						</div>
+					</div>
+				</div>
+
+				<!-- Generate Button -->
+				<button
+					on:click={handleGenerate}
+					disabled={isGenerating}
+					class="w-full bg-[#ff6b6b] hover:bg-[#ff5252] text-white px-6 py-4 border-[3px] border-black shadow-[6px_6px_0_0_#000] hover:shadow-[2px_2px_0_0_#000] hover:translate-x-[4px] hover:translate-y-[4px] transition-all font-black uppercase tracking-wide flex items-center justify-center gap-3 disabled:opacity-50 disabled:cursor-not-allowed text-lg rounded-xl"
+				>
+					{#if isGenerating}
+						<svg
+							class="animate-spin h-5 w-5"
+							xmlns="http://www.w3.org/2000/svg"
+							fill="none"
+							viewBox="0 0 24 24"
+						>
+							<circle
+								class="opacity-25"
+								cx="12"
+								cy="12"
+								r="10"
+								stroke="currentColor"
+								stroke-width="4"
+							/>
+							<path
+								class="opacity-75"
+								fill="currentColor"
+								d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+							/>
+						</svg>
+						GENERATING...
+					{:else}
+						<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+							><path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M13 10V3L4 14h7v7l9-11h-7z"
+							/></svg
+						>
+						GENERATE CERTIFICATE
+					{/if}
+				</button>
+			</div>
+		</div>
+
+		<!-- Generated Result + NextSteps -->
+		{#if generatedImageUrl}
+			<div class="max-w-4xl mx-auto px-4 mb-20 animate-fade-in-up">
+				<div
+					class="bg-[#4ade80]/10 border-[3px] border-[#4ade80] rounded-3xl p-8 text-center relative overflow-hidden"
+				>
+					<div class="absolute top-0 right-0 w-32 h-32 bg-[#4ade80]/20 rounded-full blur-2xl" />
+
+					<h3 class="text-2xl font-black text-gray-900 uppercase tracking-tight mb-6">
+						Your certificate is ready!
+					</h3>
+
+					<div
+						class="inline-block bg-white border-[3px] border-gray-900 p-2 shadow-[8px_8px_0_0_#1f2937] rotate-1 mb-8"
+					>
+						<img
+							src={generatedImageUrl}
+							alt="Generated certificate"
+							class="max-w-full h-auto max-h-[400px]"
+						/>
+					</div>
+
+					<div class="flex flex-wrap justify-center gap-4">
+						<a
+							href={generatedImageUrl}
+							download="certificate.png"
+							class="px-6 py-3 bg-white text-gray-900 border-[3px] border-gray-900 font-bold uppercase tracking-wide shadow-[4px_4px_0_0_#1f2937] hover:shadow-[2px_2px_0_0_#1f2937] hover:translate-x-[2px] hover:translate-y-[2px] transition-all rounded-xl flex items-center gap-2"
+						>
+							<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+								><path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+								/></svg
+							>
+							Download PNG
+						</a>
+						<button
+							on:click={openInCanvasEditor}
+							class="px-6 py-3 bg-[#4ade80] text-gray-900 border-[3px] border-gray-900 font-bold uppercase tracking-wide shadow-[4px_4px_0_0_#1f2937] hover:shadow-[2px_2px_0_0_#1f2937] hover:translate-x-[2px] hover:translate-y-[2px] transition-all rounded-xl flex items-center gap-2"
+						>
+							<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+								><path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+								/></svg
+							>
+							Edit in Full Editor
+						</button>
+					</div>
+				</div>
+
+				<div class="mt-12">
+					<NextSteps
+						heading="Now Automate It"
+						description="You've proved it works. Now integrate certificate generation into your app."
+						curlSnippet={apiSnippet}
+						{templateDraft}
+						generatedUrl={generatedImageUrl}
+						generatedWidth={selectedTemplate.width}
+						generatedHeight={selectedTemplate.height}
+						generatedFormat="png"
+						toolName="Certificate Generator"
+					/>
+				</div>
+			</div>
+		{:else if generationError}
+			<div class="max-w-3xl mx-auto px-4 mb-12">
+				<div
+					class="bg-red-50 border-[3px] border-red-500 rounded-2xl p-6 flex items-center gap-4"
+				>
+					<div
+						class="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center border-2 border-red-500 text-red-500 font-black"
+					>
+						!
+					</div>
+					<div>
+						<h4 class="font-black text-red-900 uppercase">Generation Failed</h4>
+						<p class="text-red-700 font-medium">{generationError}</p>
+					</div>
+					<button on:click={handleGenerate} class="ml-auto underline font-bold text-red-900"
+						>Retry</button
+					>
+				</div>
+			</div>
+		{/if}
+
+		<!-- SEO Content Sections -->
+		<div class="max-w-5xl mx-auto mt-16 sm:mt-20">
+			<!-- Separator -->
+			<div class="border-t-[3px] sm:border-t-[4px] border-black relative mb-8 sm:mb-12 lg:mb-16">
+				<div class="absolute left-1/2 -top-4 sm:-top-5 -translate-x-1/2 bg-[#FFFDF8] px-4 sm:px-6">
+					<div
+						class="w-8 h-8 sm:w-10 sm:h-10 bg-[#ffc480] border-[3px] border-black flex items-center justify-center shadow-[2px_2px_0_0_#000] sm:shadow-[3px_3px_0_0_#000]"
+					>
+						<span class="font-black text-sm sm:text-lg">?</span>
+					</div>
+				</div>
+			</div>
+
+			<h2
+				class="text-2xl sm:text-3xl md:text-5xl font-black mb-8 sm:mb-12 text-center text-gray-900 tracking-tighter px-2"
+			>
+				LEARN MORE ABOUT <br class="md:hidden" />
+				<span class="relative inline-block text-white mt-2">
+					<span class="relative z-10 px-2 sm:px-4">CERTIFICATES</span>
+					<span
+						class="absolute inset-0 bg-[#ff6b6b] transform -skew-x-2 border-[3px] sm:border-[4px] border-black shadow-[4px_4px_0_0_#000] sm:shadow-[6px_6px_0_0_#000] -z-0"
+					/>
+				</span>
+			</h2>
+
+			<!-- What is Section -->
+			<section
+				class="mb-8 sm:mb-12 bg-white border-[3px] border-black shadow-[4px_4px_0_0_#000] sm:shadow-[8px_8px_0_0_#000] p-4 sm:p-6 md:p-10 hover:shadow-[2px_2px_0_0_#000] sm:hover:shadow-[4px_4px_0_0_#000] hover:translate-x-[2px] hover:translate-y-[2px] sm:hover:translate-x-[4px] sm:hover:translate-y-[4px] transition-all duration-300"
+			>
+				<div
+					class="inline-flex items-center gap-2 px-3 sm:px-4 py-1 bg-[#ffc480] border-[3px] border-black text-[10px] sm:text-xs font-black uppercase tracking-wider mb-4 sm:mb-6 shadow-[2px_2px_0_0_#000] sm:shadow-[3px_3px_0_0_#000]"
+				>
+					<svg class="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+						><path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M13 10V3L4 14h7v7l9-11h-7z"
+						/></svg
+					>
+					Overview
+				</div>
+				<h3
+					class="text-xl sm:text-2xl md:text-3xl font-black mb-4 sm:mb-6 text-black tracking-tight"
+				>
+					What is a Certificate Generator?
+				</h3>
+				<p class="text-sm sm:text-base text-gray-700 leading-relaxed font-medium">
+					A certificate generator is a tool that lets you create professional, customizable certificates for any occasion.
+					Whether you need certificates for course completions, employee awards, event attendance, or academic achievements,
+					a certificate generator streamlines the process from design to download. Instead of spending hours in graphic
+					design software, you can select a template, fill in the details, and generate a print-ready certificate in seconds.
+				</p>
+			</section>
+
+			<!-- Benefits Section -->
+			<section
+				class="mb-8 sm:mb-12 bg-white border-[3px] border-black shadow-[4px_4px_0_0_#000] sm:shadow-[8px_8px_0_0_#000] p-4 sm:p-6 md:p-10 hover:shadow-[2px_2px_0_0_#000] sm:hover:shadow-[4px_4px_0_0_#000] hover:translate-x-[2px] hover:translate-y-[2px] sm:hover:translate-x-[4px] sm:hover:translate-y-[4px] transition-all duration-300"
+			>
+				<div
+					class="inline-flex items-center gap-2 px-3 sm:px-4 py-1 bg-[#4ade80] border-[3px] border-black text-[10px] sm:text-xs font-black uppercase tracking-wider mb-4 sm:mb-6 shadow-[2px_2px_0_0_#000] sm:shadow-[3px_3px_0_0_#000]"
+				>
+					<svg class="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+						><path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
+						/></svg
+					>
+					Benefits
+				</div>
+				<h3
+					class="text-xl sm:text-2xl md:text-3xl font-black mb-4 sm:mb-6 text-black tracking-tight"
+				>
+					Why Use Our Certificate Generator?
+				</h3>
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+					{#each ['5 professionally designed certificate templates', 'Real-time interactive canvas preview', 'Customize recipient name, organization, date, and achievement', 'High-resolution 1920x1080px PNG output', 'API available for bulk certificate generation', 'No signup required to get started'] as benefit}
+						<div
+							class="bg-[#f8f8f8] border-[3px] border-black p-3 shadow-[3px_3px_0_0_#000] flex items-center gap-3 hover:shadow-[1px_1px_0_0_#000] hover:translate-x-[2px] hover:translate-y-[2px] transition-all"
+						>
+							<span class="font-black text-[#4ade80]">&#10003;</span>
+							<span class="font-bold text-black text-sm">{benefit}</span>
+						</div>
+					{/each}
+				</div>
+			</section>
+
+			<!-- How to Use Section -->
+			<section
+				class="mb-8 sm:mb-12 bg-white border-[3px] border-black shadow-[4px_4px_0_0_#000] sm:shadow-[8px_8px_0_0_#000] p-4 sm:p-6 md:p-10 hover:shadow-[2px_2px_0_0_#000] sm:hover:shadow-[4px_4px_0_0_#000] hover:translate-x-[2px] hover:translate-y-[2px] sm:hover:translate-x-[4px] sm:hover:translate-y-[4px] transition-all duration-300"
+			>
+				<div
+					class="inline-flex items-center gap-2 px-3 sm:px-4 py-1 bg-[#60a5fa] border-[3px] border-black text-white text-[10px] sm:text-xs font-black uppercase tracking-wider mb-4 sm:mb-6 shadow-[2px_2px_0_0_#000] sm:shadow-[3px_3px_0_0_#000]"
+				>
+					<svg class="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+						><path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+						/><path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+						/></svg
+					>
+					Guide
+				</div>
+				<h3
+					class="text-xl sm:text-2xl md:text-3xl font-black mb-4 sm:mb-6 text-black tracking-tight"
+				>
+					How to Create a Certificate
+				</h3>
+				<div class="space-y-4">
+					{#each [{ num: '1', text: 'Choose a certificate template from the gallery above' }, { num: '2', text: 'Enter the recipient name, organization, date, and achievement' }, { num: '3', text: 'Preview your certificate in the interactive canvas editor' }, { num: '4', text: 'Click any text on the canvas to make direct edits' }, { num: '5', text: 'Click "Generate Certificate" to create a high-resolution PNG' }, { num: '6', text: 'Download your certificate or open it in the full editor for further customization' }] as step}
+						<div class="flex items-start gap-4">
+							<span
+								class="bg-[#60a5fa] text-white w-8 h-8 flex items-center justify-center font-black flex-shrink-0 border-[3px] border-black shadow-[2px_2px_0_0_#000]"
+								>{step.num}</span
+							>
+							<span class="font-bold text-black text-sm pt-1">{step.text}</span>
+						</div>
+					{/each}
+				</div>
+			</section>
+
+			<!-- FAQ Section -->
+			<section
+				class="mb-8 sm:mb-12 bg-white border-[3px] border-black shadow-[4px_4px_0_0_#000] sm:shadow-[8px_8px_0_0_#000] p-4 sm:p-6 md:p-10 hover:shadow-[2px_2px_0_0_#000] sm:hover:shadow-[4px_4px_0_0_#000] hover:translate-x-[2px] hover:translate-y-[2px] sm:hover:translate-x-[4px] sm:hover:translate-y-[4px] transition-all duration-300"
+			>
+				<div
+					class="inline-flex items-center gap-2 px-3 sm:px-4 py-1 bg-[#ff6b6b] border-[3px] border-black text-white text-[10px] sm:text-xs font-black uppercase tracking-wider mb-4 sm:mb-6 shadow-[2px_2px_0_0_#000] sm:shadow-[3px_3px_0_0_#000]"
+				>
+					<svg class="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+						><path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+						/></svg
+					>
+					FAQ
+				</div>
+				<h3
+					class="text-xl sm:text-2xl md:text-3xl font-black mb-4 sm:mb-6 text-black tracking-tight"
+				>
+					Frequently Asked Questions
+				</h3>
+				<div class="space-y-3">
+					{#each faqs as faq}
+						<details
+							class="group bg-[#f8f8f8] border-[3px] border-black overflow-hidden shadow-[3px_3px_0_0_#000] hover:shadow-[1px_1px_0_0_#000] hover:translate-x-[2px] hover:translate-y-[2px] transition-all"
+						>
+							<summary
+								class="flex items-center justify-between cursor-pointer p-4 font-bold text-black select-none text-sm"
+							>
+								<span>{faq.q}</span>
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									class="h-5 w-5 text-black group-open:rotate-180 transition-transform duration-300 flex-shrink-0"
+									viewBox="0 0 20 20"
+									fill="currentColor"
+								>
+									<path
+										fill-rule="evenodd"
+										d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+										clip-rule="evenodd"
+									/>
+								</svg>
+							</summary>
+							<div class="p-4 pt-0 text-gray-600 border-t-[3px] border-black bg-white text-sm">
+								{faq.a}
+							</div>
+						</details>
+					{/each}
+				</div>
+			</section>
+
+			<!-- Open in Editor CTA -->
+			<section class="mb-12 sm:mb-16 text-center">
+				<div
+					class="bg-gray-900 border-[3px] border-black rounded-3xl p-8 sm:p-12 relative overflow-hidden"
+				>
+					<div
+						class="absolute top-0 right-0 w-40 h-40 bg-[#ffc480]/20 rounded-full blur-2xl pointer-events-none"
+					/>
+					<div
+						class="absolute bottom-0 left-0 w-32 h-32 bg-[#ff6b6b]/20 rounded-full blur-2xl pointer-events-none"
+					/>
+
+					<h3
+						class="text-2xl sm:text-3xl font-black text-white uppercase tracking-tight mb-4 relative z-10"
+					>
+						Need More Customization?
+					</h3>
+					<p class="text-gray-400 font-bold mb-8 max-w-lg mx-auto relative z-10">
+						Open your certificate in our full canvas editor to add logos, custom images, QR codes,
+						and fine-tune every design detail.
+					</p>
+					<button
+						type="button"
+						on:click={openInCanvasEditor}
+						class="px-8 py-4 bg-[#ffc480] text-gray-900 border-[3px] border-gray-900 font-black text-lg uppercase tracking-wide shadow-[6px_6px_0_0_#ffc480] hover:shadow-[3px_3px_0_0_#ffc480] hover:translate-x-[3px] hover:translate-y-[3px] transition-all inline-flex items-center gap-3 rounded-2xl relative z-10"
+					>
+						<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+							><path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+							/></svg
+						>
+						Open Full Editor — Free
+					</button>
+				</div>
+			</section>
+		</div>
+	</main>
+
+	<RelatedTools tools={['badge', 'course-certificate', 'receipt', 'event-ticket']} />
+
+	<Footer />
+</section>


### PR DESCRIPTION
Add interactive certificate generator at /tools/certificate-generator 

- 5 visually distinct FabricJS certificate templates (Elegant, Modern Dark, Corporate, Minimalist, Creative) with variable bindings for recipientName, organizationName, date, and achievementText
- Extended MiniEditor with setVariableValue() and getVariables() methods for form-driven canvas updates (backwards-compatible)
- Full SEO: WebApplication + FAQPage + BreadcrumbList structured data, optimized title/meta/canonical/OG tags
- Interactive canvas preview with 150ms debounced form-to-canvas sync
- Generation via existing POST /image/public/canvas endpoint (zero backend changes)
- Template gallery, variable input form, download, NextSteps, "Open in Full Editor" CTA
- Added to tools index page and pSEO certificate config