### PR TITLE
fix(plg): wire upgrade prompts + milestones to record server engagement (PIC-30)

### DIFF
--- a/src/api/plg.js
+++ b/src/api/plg.js
@@ -54,6 +54,18 @@ export const recordUpgradePrompt = async (action, promptType, context = {}) => {
 };
 
 /**
+ * Record that a discount code was applied at checkout
+ */
+export const recordDiscountCodeUsed = async (code, context = {}) => {
+	try {
+		const response = await backend.post('/api/plg/discount-code-used', { code, context });
+		return response;
+	} catch (error) {
+		return { success: false };
+	}
+};
+
+/**
  * Get discount code
  */
 export const getDiscountCode = async (percentage) => {

--- a/src/config/personalization.js
+++ b/src/config/personalization.js
@@ -210,17 +210,6 @@ export const GETTING_STARTED_STEPS = {
 	exploring: [
 		{
 			number: 1,
-			title: 'Generate an image with HTML',
-			description: 'Paste any HTML/CSS below and get an image back — no signup or template needed.',
-			href: '/tools/html-to-image',
-			cta: 'Try It',
-			color: '#ffc480',
-			icon: 'code',
-			completedCheck: null,
-			code: null
-		},
-		{
-			number: 2,
 			title: 'Open the template editor',
 			description: 'Build a reusable template with the drag-and-drop editor.',
 			href: '/template-workspace/create',
@@ -231,14 +220,14 @@ export const GETTING_STARTED_STEPS = {
 			code: null
 		},
 		{
-			number: 3,
+			number: 2,
 			title: 'Try the API playground',
-			description: 'Test API endpoints interactively and see live responses.',
+			description: 'Test API endpoints interactively and generate your first image.',
 			href: '/dashboard/api-playground',
 			cta: 'Open Playground',
 			color: '#4ade80',
 			icon: 'code',
-			completedCheck: null,
+			completedCheck: 'hasImages',
 			code: null
 		}
 	]

--- a/src/lib/components/plg/MilestoneCelebration.svelte
+++ b/src/lib/components/plg/MilestoneCelebration.svelte
@@ -1,15 +1,44 @@
 <script>
 	import { fade, scale, fly } from 'svelte/transition';
 	import { elasticOut, quintOut } from 'svelte/easing';
-	import { activeMilestone, dismissMilestone } from '../../../store/plg.store';
+	import { activeMilestone, dismissMilestone as dismissMilestoneStore } from '../../../store/plg.store';
 	import { openUpgradeModal } from '../../../store/upgrade-modal.store';
+	import { recordUpgradePrompt } from '../../../api/plg.js';
 	import { goto } from '$app/navigation';
 
 	// Confetti particles
 	let particles = [];
+	let lastShownId = null;
+
+	const UPSELL_TYPES = new Set(['soft_upsell', 'urgent_upsell', 'limit_reached']);
 
 	$: if ($activeMilestone) {
 		createConfetti();
+		recordShownIfUpsell($activeMilestone);
+	}
+
+	function recordShownIfUpsell(milestone) {
+		if (!milestone || !UPSELL_TYPES.has(milestone.type)) return;
+		const id = milestone.id || `${milestone.feature || 'renders'}-${milestone.count}`;
+		if (id === lastShownId) return;
+		lastShownId = id;
+		recordUpgradePrompt('shown', 'milestone', {
+			milestone_id: id,
+			milestone_type: milestone.type,
+			count: milestone.count,
+			discount: milestone.cta?.discount || null
+		});
+	}
+
+	async function dismissMilestone() {
+		const milestone = $activeMilestone;
+		if (milestone && UPSELL_TYPES.has(milestone.type)) {
+			recordUpgradePrompt('dismissed', 'milestone', {
+				milestone_id: milestone.id || `${milestone.feature || 'renders'}-${milestone.count}`,
+				milestone_type: milestone.type
+			});
+		}
+		await dismissMilestoneStore();
 	}
 
 	function createConfetti() {
@@ -41,6 +70,13 @@
 		switch (action) {
 			case 'upgrade':
 			case 'pricing':
+				if (UPSELL_TYPES.has(milestone.type)) {
+					recordUpgradePrompt('clicked', 'milestone', {
+						milestone_id: milestone.id || `${milestone.feature || 'renders'}-${milestone.count}`,
+						milestone_type: milestone.type,
+						discount: milestone.cta?.discount || null
+					});
+				}
 				dismissMilestone();
 				openUpgradeModal('milestone');
 				break;

--- a/src/lib/components/plg/MilestoneCelebration.svelte
+++ b/src/lib/components/plg/MilestoneCelebration.svelte
@@ -1,7 +1,10 @@
 <script>
 	import { fade, scale, fly } from 'svelte/transition';
 	import { elasticOut, quintOut } from 'svelte/easing';
-	import { activeMilestone, dismissMilestone as dismissMilestoneStore } from '../../../store/plg.store';
+	import {
+		activeMilestone,
+		dismissMilestone as dismissMilestoneStore
+	} from '../../../store/plg.store';
 	import { openUpgradeModal } from '../../../store/upgrade-modal.store';
 	import { recordUpgradePrompt } from '../../../api/plg.js';
 	import { goto } from '$app/navigation';
@@ -30,6 +33,12 @@
 		});
 	}
 
+	// Close the celebration without recording a funnel event. The CTA path uses this
+	// and records 'clicked' instead — 'clicked' and 'dismissed' are mutually exclusive.
+	function closeMilestone() {
+		return dismissMilestoneStore();
+	}
+
 	async function dismissMilestone() {
 		const milestone = $activeMilestone;
 		if (milestone && UPSELL_TYPES.has(milestone.type)) {
@@ -38,7 +47,7 @@
 				milestone_type: milestone.type
 			});
 		}
-		await dismissMilestoneStore();
+		await closeMilestone();
 	}
 
 	function createConfetti() {
@@ -77,7 +86,7 @@
 						discount: milestone.cta?.discount || null
 					});
 				}
-				dismissMilestone();
+				closeMilestone();
 				openUpgradeModal('milestone');
 				break;
 			case 'templates':

--- a/src/lib/components/plg/ProactiveUpgradeModal.svelte
+++ b/src/lib/components/plg/ProactiveUpgradeModal.svelte
@@ -11,6 +11,7 @@
 		getDiscountForUsage
 	} from '../../../store/plg.store';
 	import { openUpgradeModal } from '../../../store/upgrade-modal.store';
+	import { recordUpgradePrompt } from '../../../api/plg.js';
 	import { analytics } from '$lib/analytics.js';
 
 	let showModal = false;
@@ -44,6 +45,11 @@
 				time_saved: $plgStatus.timeSaved?.display,
 				discount_code: discountInfo.discountCode
 			});
+			recordUpgradePrompt('shown', 'proactive_modal', {
+				percentage: $usageWidget.percentage,
+				renders_completed: $usageWidget.current,
+				discount_code: discountInfo.discountCode
+			});
 		}
 	}
 
@@ -51,6 +57,9 @@
 		analytics.track('proactive_modal_dismissed', {
 			percentage: $usageWidget.percentage,
 			plan: $usageWidget.plan
+		});
+		recordUpgradePrompt('dismissed', 'proactive_modal', {
+			percentage: $usageWidget.percentage
 		});
 		showModal = false;
 	}
@@ -60,6 +69,10 @@
 			percentage: $usageWidget.percentage,
 			plan: $usageWidget.plan,
 			discount: discountInfo.discountPercent,
+			discount_code: discountInfo.discountCode
+		});
+		recordUpgradePrompt('clicked', 'proactive_modal', {
+			percentage: $usageWidget.percentage,
 			discount_code: discountInfo.discountCode
 		});
 		showModal = false;

--- a/src/lib/components/plg/ProactiveUpgradeModal.svelte
+++ b/src/lib/components/plg/ProactiveUpgradeModal.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { fade, scale } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
 	import {
@@ -8,7 +8,9 @@
 		shouldShowProactiveModal,
 		markProactiveModalShown,
 		initNudgeState,
-		getDiscountForUsage
+		getDiscountForUsage,
+		requestPrompt,
+		releasePrompt
 	} from '../../../store/plg.store';
 	import { openUpgradeModal } from '../../../store/upgrade-modal.store';
 	import { recordUpgradePrompt } from '../../../api/plg.js';
@@ -29,13 +31,20 @@
 		initNudgeState();
 	});
 
+	onDestroy(() => {
+		// Free the slot if the modal is torn down while open (e.g. route change).
+		releasePrompt('proactive_modal');
+	});
+
 	// Check when usage changes and hits 75%
 	$: if (mounted && $plgStatus.loaded && $usageWidget.percentage >= 75) {
 		checkModalVisibility();
 	}
 
 	function checkModalVisibility() {
-		if (shouldShowProactiveModal()) {
+		// Single-prompt coordinator: only show if no other PLG modal holds the slot.
+		// If denied, leave it un-marked so it can retry on the next usage update.
+		if (shouldShowProactiveModal() && requestPrompt('proactive_modal')) {
 			showModal = true;
 			markProactiveModalShown();
 			analytics.track('proactive_modal_shown', {
@@ -62,6 +71,7 @@
 			percentage: $usageWidget.percentage
 		});
 		showModal = false;
+		releasePrompt('proactive_modal');
 	}
 
 	function handleUpgradeClick() {
@@ -76,6 +86,7 @@
 			discount_code: discountInfo.discountCode
 		});
 		showModal = false;
+		releasePrompt('proactive_modal');
 		openUpgradeModal('proactive_modal', discountInfo.discountCode);
 	}
 

--- a/src/lib/components/plg/UsageBanner.svelte
+++ b/src/lib/components/plg/UsageBanner.svelte
@@ -12,11 +12,13 @@
 		getDiscountForUsage
 	} from '../../../store/plg.store';
 	import { openUpgradeModal } from '../../../store/upgrade-modal.store';
+	import { recordUpgradePrompt } from '../../../api/plg.js';
 	import { analytics } from '$lib/analytics.js';
 	import { goto } from '$app/navigation';
 
 	let showBanner = false;
 	let mounted = false;
+	let lastShownAtPercentage = null;
 
 	// Get discount info based on current usage
 	$: discountInfo = getDiscountForUsage($usageWidget.percentage);
@@ -78,12 +80,18 @@
 	});
 
 	function checkBannerVisibility() {
+		const wasShown = showBanner;
 		showBanner = shouldShowUsageBanner();
-		if (showBanner) {
+		if (showBanner && (!wasShown || lastShownAtPercentage !== $usageWidget.percentage)) {
+			lastShownAtPercentage = $usageWidget.percentage;
 			analytics.track('usage_banner_shown', {
 				percentage: $usageWidget.percentage,
 				plan: $usageWidget.plan,
 				discount_code: discountInfo?.discountCode
+			});
+			recordUpgradePrompt('shown', 'usage_banner', {
+				percentage: $usageWidget.percentage,
+				discount_code: discountInfo?.discountCode || null
 			});
 		}
 	}
@@ -98,6 +106,9 @@
 			percentage: $usageWidget.percentage,
 			plan: $usageWidget.plan
 		});
+		recordUpgradePrompt('dismissed', 'usage_banner', {
+			percentage: $usageWidget.percentage
+		});
 		dismissUsageBanner();
 		showBanner = false;
 	}
@@ -108,6 +119,10 @@
 			plan: $usageWidget.plan,
 			discount_code: discountInfo?.discountCode,
 			overage_enabled: overageEnabled
+		});
+		recordUpgradePrompt('clicked', 'usage_banner', {
+			percentage: $usageWidget.percentage,
+			discount_code: discountInfo?.discountCode || null
 		});
 
 		// If at limit with overages enabled, go to billing settings instead

--- a/src/lib/components/plg/UsageBanner.svelte
+++ b/src/lib/components/plg/UsageBanner.svelte
@@ -18,7 +18,6 @@
 
 	let showBanner = false;
 	let mounted = false;
-	let lastShownAtPercentage = null;
 
 	// Get discount info based on current usage
 	$: discountInfo = getDiscountForUsage($usageWidget.percentage);
@@ -82,8 +81,9 @@
 	function checkBannerVisibility() {
 		const wasShown = showBanner;
 		showBanner = shouldShowUsageBanner();
-		if (showBanner && (!wasShown || lastShownAtPercentage !== $usageWidget.percentage)) {
-			lastShownAtPercentage = $usageWidget.percentage;
+		// Record one impression per appearance (hidden -> shown), not per percentage
+		// tick. Re-appearance after the 24h dismiss cooldown counts as a new impression.
+		if (showBanner && !wasShown) {
 			analytics.track('usage_banner_shown', {
 				percentage: $usageWidget.percentage,
 				plan: $usageWidget.plan,

--- a/src/lib/components/plg/UsageBanner.svelte
+++ b/src/lib/components/plg/UsageBanner.svelte
@@ -148,7 +148,7 @@
 
 {#if bannerVisible}
 	<div
-		class="w-full {bannerStyle} border-b-[3px] border-gray-900 shadow-sm relative z-40"
+		class="w-full {bannerStyle} border-b-[3px] border-gray-900 shadow-sm relative z-20"
 		transition:slide={{ duration: 200 }}
 	>
 		<div class="max-w-7xl mx-auto px-4 py-3">

--- a/src/lib/components/plg/UsageBanner.svelte
+++ b/src/lib/components/plg/UsageBanner.svelte
@@ -9,7 +9,8 @@
 		shouldShowUsageBanner,
 		dismissUsageBanner,
 		initNudgeState,
-		getDiscountForUsage
+		getDiscountForUsage,
+		activePrompt
 	} from '../../../store/plg.store';
 	import { openUpgradeModal } from '../../../store/upgrade-modal.store';
 	import { recordUpgradePrompt } from '../../../api/plg.js';
@@ -18,6 +19,7 @@
 
 	let showBanner = false;
 	let mounted = false;
+	let impressionLogged = false;
 
 	// Get discount info based on current usage
 	$: discountInfo = getDiscountForUsage($usageWidget.percentage);
@@ -79,26 +81,35 @@
 	});
 
 	function checkBannerVisibility() {
-		const wasShown = showBanner;
 		showBanner = shouldShowUsageBanner();
-		// Record one impression per appearance (hidden -> shown), not per percentage
-		// tick. Re-appearance after the 24h dismiss cooldown counts as a new impression.
-		if (showBanner && !wasShown) {
-			analytics.track('usage_banner_shown', {
-				percentage: $usageWidget.percentage,
-				plan: $usageWidget.plan,
-				discount_code: discountInfo?.discountCode
-			});
-			recordUpgradePrompt('shown', 'usage_banner', {
-				percentage: $usageWidget.percentage,
-				discount_code: discountInfo?.discountCode || null
-			});
-		}
 	}
 
-	// Re-check when usage changes
+	// Re-check eligibility whenever usage changes.
 	$: if (mounted && $plgStatus.loaded) {
 		checkBannerVisibility();
+	}
+
+	// Reset the impression guard when the banner leaves the eligible state, so the
+	// next appearance (e.g. after the 24h dismiss cooldown) logs a fresh impression.
+	$: if (!showBanner) impressionLogged = false;
+
+	// Single-prompt coordinator: the banner yields to any active PLG modal. It only
+	// renders when eligible AND no modal currently holds the slot.
+	$: bannerVisible = showBanner && $activePrompt === null;
+
+	// Log exactly one impression the first time the banner is actually visible in an
+	// eligibility window (a modal transiently covering it must not double-count).
+	$: if (bannerVisible && !impressionLogged) {
+		impressionLogged = true;
+		analytics.track('usage_banner_shown', {
+			percentage: $usageWidget.percentage,
+			plan: $usageWidget.plan,
+			discount_code: discountInfo?.discountCode
+		});
+		recordUpgradePrompt('shown', 'usage_banner', {
+			percentage: $usageWidget.percentage,
+			discount_code: discountInfo?.discountCode || null
+		});
 	}
 
 	function handleDismiss() {
@@ -135,7 +146,7 @@
 	}
 </script>
 
-{#if showBanner}
+{#if bannerVisible}
 	<div
 		class="w-full {bannerStyle} border-b-[3px] border-gray-900 shadow-sm relative z-40"
 		transition:slide={{ duration: 200 }}

--- a/src/routes/dashboard/upgrade/+page.svelte
+++ b/src/routes/dashboard/upgrade/+page.svelte
@@ -6,6 +6,7 @@
 	import { getProducts } from '../../../api/product';
 	import Loader from '$lib/components/Loader.svelte';
 	import { analytics } from '$lib/analytics.js';
+	import { recordDiscountCodeUsed } from '../../../api/plg.js';
 	import { PLANS, FEATURES, PLAN_FEATURES, formatLimit } from '../../../config/plan-features.js';
 
 	let isLoading = true;
@@ -134,6 +135,16 @@
 			// Append discount code to LemonSqueezy checkout URL if present
 			if (discountCode) {
 				customParams.push(`checkout[discount_code]=${encodeURIComponent(discountCode)}`);
+				// Also pass through custom_data so the webhook can attribute the code on subscription_created
+				customParams.push(
+					`checkout[custom][discount_code]=${encodeURIComponent(discountCode)}`
+				);
+				// Fire-and-forget: record on plgEngagement.discountCodesUsed.
+				// Best-effort attribution at intent-to-checkout time — the webhook can confirm later.
+				recordDiscountCodeUsed(discountCode, {
+					plan: plan.name,
+					source: source || 'dashboard_upgrade'
+				});
 			}
 
 			// Join all parameters with the checkout URL

--- a/src/routes/dashboard/upgrade/+page.svelte
+++ b/src/routes/dashboard/upgrade/+page.svelte
@@ -13,6 +13,9 @@
 	let allPlans = [];
 	let error = null;
 	let showAnnual = false;
+	// Record a discount intent once per page visit, even if the user clicks
+	// multiple plan cards before navigation completes.
+	let discountRecorded = false;
 
 	$: isLoggedIn = !!$user.email;
 	$: currentPlan = $user.currentPlan || 'starter';
@@ -141,10 +144,14 @@
 				);
 				// Fire-and-forget: record on plgEngagement.discountCodesUsed.
 				// Best-effort attribution at intent-to-checkout time — the webhook can confirm later.
-				recordDiscountCodeUsed(discountCode, {
-					plan: plan.name,
-					source: source || 'dashboard_upgrade'
-				});
+				// Guard against double-recording on rapid multi-card clicks before navigation.
+				if (!discountRecorded) {
+					discountRecorded = true;
+					recordDiscountCodeUsed(discountCode, {
+						plan: plan.name,
+						source: source || 'dashboard_upgrade'
+					});
+				}
 			}
 
 			// Join all parameters with the checkout URL

--- a/src/store/plg.store.js
+++ b/src/store/plg.store.js
@@ -177,6 +177,8 @@ export const urgencyLevel = derived(usageWidget, ($usageWidget) => $usageWidget.
  */
 export const resetPLG = () => {
 	_initPLGPromise = null;
+	_lastSeenRenderCount = null;
+	_lastSeenPercentage = null;
 	plgStatus.set({
 		plan: 'starter',
 		isPaidPlan: false,
@@ -333,6 +335,13 @@ const _doInitPLG = async () => {
 	}
 };
 
+// Track previous render count so we can detect milestone/threshold crossings
+let _lastSeenRenderCount = null;
+let _lastSeenPercentage = null;
+
+const RENDER_MILESTONE_COUNTS = [1, 5, 10, 25, 40, 50];
+const UPSELL_THRESHOLDS = [50, 65, 75, 85, 95, 100];
+
 /**
  * Refresh usage widget (lightweight update)
  */
@@ -350,8 +359,35 @@ export const refreshUsageWidget = async () => {
 		const percentage = limit > 0 ? Math.round((usage / limit) * 100) : 0;
 		const remaining = Math.max(0, limit - usage);
 
-		// Use normalized plan from backend (single source of truth)
+		// Detect render milestone crossings (only on increase, paid users skipped)
 		const plan = planDetails.plan ? normalizePlan(planDetails.plan) : PLANS.STARTER;
+		const isFreePlan = plan === PLANS.STARTER;
+		if (isFreePlan && _lastSeenRenderCount !== null && usage > _lastSeenRenderCount) {
+			const crossed = RENDER_MILESTONE_COUNTS.find(
+				(c) => c > _lastSeenRenderCount && c <= usage
+			);
+			if (crossed) {
+				const milestone = getMilestoneConfig('renders', crossed);
+				if (milestone) {
+					showMilestoneCelebration({
+						...milestone,
+						id: `renders-${crossed}`,
+						feature: 'renders'
+					});
+				}
+			}
+			const crossedThreshold = UPSELL_THRESHOLDS.find(
+				(t) => (_lastSeenPercentage === null || t > _lastSeenPercentage) && t <= percentage
+			);
+			if (crossedThreshold) {
+				const threshold = getThresholdConfig(crossedThreshold);
+				if (threshold && threshold.showUpgrade) {
+					showThresholdPrompt(threshold);
+				}
+			}
+		}
+		_lastSeenRenderCount = usage;
+		_lastSeenPercentage = percentage;
 
 		const isPaidPlan = plan !== PLANS.STARTER;
 

--- a/src/store/plg.store.js
+++ b/src/store/plg.store.js
@@ -363,9 +363,12 @@ export const refreshUsageWidget = async () => {
 		const plan = planDetails.plan ? normalizePlan(planDetails.plan) : PLANS.STARTER;
 		const isFreePlan = plan === PLANS.STARTER;
 		if (isFreePlan && _lastSeenRenderCount !== null && usage > _lastSeenRenderCount) {
-			const crossed = RENDER_MILESTONE_COUNTS.find(
+			// If several milestones were crossed since the last poll, surface the
+			// highest one reached (a 0->50 jump should celebrate "maxed out", not
+			// "first render"). Counts are ascending, so pop() is the highest crossed.
+			const crossed = RENDER_MILESTONE_COUNTS.filter(
 				(c) => c > _lastSeenRenderCount && c <= usage
-			);
+			).pop();
 			if (crossed) {
 				const milestone = getMilestoneConfig('renders', crossed);
 				if (milestone) {
@@ -376,11 +379,13 @@ export const refreshUsageWidget = async () => {
 					});
 				}
 			}
-			const crossedThreshold = UPSELL_THRESHOLDS.find(
+			// Likewise, if usage jumped past several thresholds, show the prompt for
+			// the user's *current* urgency, not the lowest band we happened to cross.
+			const crossedThreshold = UPSELL_THRESHOLDS.some(
 				(t) => (_lastSeenPercentage === null || t > _lastSeenPercentage) && t <= percentage
 			);
 			if (crossedThreshold) {
-				const threshold = getThresholdConfig(crossedThreshold);
+				const threshold = getThresholdConfig(percentage);
 				if (threshold && threshold.showUpgrade) {
 					showThresholdPrompt(threshold);
 				}

--- a/src/store/plg.store.js
+++ b/src/store/plg.store.js
@@ -111,6 +111,27 @@ export const activeMilestone = writable(null);
 // Active upgrade prompt
 export const activeUpgradePrompt = writable(null);
 
+// ---- Single-prompt coordinator ----------------------------------------------
+// Only one interruptive PLG modal (milestone celebration, threshold/feature-limit
+// upgrade modal, or proactive upgrade modal) may be visible at a time. Each modal
+// claims the slot before showing and frees it on close. The ambient usage banner is
+// not a claimant — it observes `activePrompt` and steps aside while a modal is up.
+export const activePrompt = writable(null);
+
+// Claim the single modal slot for `surface`. Non-preemptive: returns false if a
+// different surface already holds it (the first claimant wins until it releases).
+export const requestPrompt = (surface) => {
+	const current = get(activePrompt);
+	if (current && current !== surface) return false;
+	activePrompt.set(surface);
+	return true;
+};
+
+// Release the slot, but only if `surface` is the current holder.
+export const releasePrompt = (surface) => {
+	if (get(activePrompt) === surface) activePrompt.set(null);
+};
+
 // Feature gate status (for checking before using features)
 export const featureGates = writable({});
 
@@ -179,6 +200,7 @@ export const resetPLG = () => {
 	_initPLGPromise = null;
 	_lastSeenRenderCount = null;
 	_lastSeenPercentage = null;
+	activePrompt.set(null);
 	plgStatus.set({
 		plan: 'starter',
 		isPaidPlan: false,
@@ -363,9 +385,24 @@ export const refreshUsageWidget = async () => {
 		const plan = planDetails.plan ? normalizePlan(planDetails.plan) : PLANS.STARTER;
 		const isFreePlan = plan === PLANS.STARTER;
 		if (isFreePlan && _lastSeenRenderCount !== null && usage > _lastSeenRenderCount) {
-			// If several milestones were crossed since the last poll, surface the
-			// highest one reached (a 0->50 jump should celebrate "maxed out", not
-			// "first render"). Counts are ascending, so pop() is the highest crossed.
+			// Only one prompt is shown per crossing (single-prompt coordinator). Try the
+			// usage-threshold upgrade modal first: at high usage it's the actionable
+			// surface (tiered discount + upgrade CTA), so it should win the slot over the
+			// milestone celebration. Show the prompt for the user's *current* urgency,
+			// not the lowest band we happened to cross.
+			const crossedThreshold = UPSELL_THRESHOLDS.some(
+				(t) => (_lastSeenPercentage === null || t > _lastSeenPercentage) && t <= percentage
+			);
+			if (crossedThreshold) {
+				const threshold = getThresholdConfig(percentage);
+				if (threshold && threshold.showUpgrade) {
+					showThresholdPrompt(threshold);
+				}
+			}
+			// If several milestones were crossed since the last poll, surface the highest
+			// one reached (a 0->50 jump should celebrate "maxed out", not "first render").
+			// Counts are ascending, so pop() is the highest crossed. The coordinator drops
+			// this if the threshold modal above already claimed the slot.
 			const crossed = RENDER_MILESTONE_COUNTS.filter(
 				(c) => c > _lastSeenRenderCount && c <= usage
 			).pop();
@@ -377,17 +414,6 @@ export const refreshUsageWidget = async () => {
 						id: `renders-${crossed}`,
 						feature: 'renders'
 					});
-				}
-			}
-			// Likewise, if usage jumped past several thresholds, show the prompt for
-			// the user's *current* urgency, not the lowest band we happened to cross.
-			const crossedThreshold = UPSELL_THRESHOLDS.some(
-				(t) => (_lastSeenPercentage === null || t > _lastSeenPercentage) && t <= percentage
-			);
-			if (crossedThreshold) {
-				const threshold = getThresholdConfig(percentage);
-				if (threshold && threshold.showUpgrade) {
-					showThresholdPrompt(threshold);
 				}
 			}
 		}
@@ -639,6 +665,8 @@ export const isPaidUser = derived(plgStatus, ($plgStatus) => {
  * Show milestone celebration
  */
 export const showMilestoneCelebration = (milestone) => {
+	// Single-prompt coordinator: don't stack on top of another active PLG modal.
+	if (!requestPrompt('milestone')) return;
 	activeMilestone.set(milestone);
 
 	// Auto-dismiss after 8 seconds for celebrations
@@ -664,12 +692,15 @@ export const dismissMilestone = async () => {
 		}
 	}
 	activeMilestone.set(null);
+	releasePrompt('milestone');
 };
 
 /**
  * Show feature limit upgrade prompt
  */
 export const showFeatureLimitPrompt = (feature, result) => {
+	// Single-prompt coordinator: don't stack on top of another active PLG modal.
+	if (!requestPrompt('upgrade_modal')) return;
 	activeUpgradePrompt.set({
 		type: 'feature_limit',
 		feature,
@@ -696,6 +727,8 @@ export const showFeatureLimitPrompt = (feature, result) => {
  */
 export const showThresholdPrompt = (threshold) => {
 	if (!threshold || threshold.type === 'info') return;
+	// Single-prompt coordinator: don't stack on top of another active PLG modal.
+	if (!requestPrompt('upgrade_modal')) return;
 
 	activeUpgradePrompt.set({
 		type: 'threshold',
@@ -713,6 +746,15 @@ export const showThresholdPrompt = (threshold) => {
 };
 
 /**
+ * Close the upgrade prompt without recording a dismissal (used by the CTA path,
+ * which records 'clicked' instead) and free the single-prompt slot.
+ */
+export const closeUpgradePrompt = () => {
+	activeUpgradePrompt.set(null);
+	releasePrompt('upgrade_modal');
+};
+
+/**
  * Dismiss upgrade prompt
  */
 export const dismissUpgradePrompt = () => {
@@ -721,7 +763,7 @@ export const dismissUpgradePrompt = () => {
 		recordUpgradePrompt('dismissed', prompt.type, prompt);
 		analytics.trackUpgradePromptDismissed({ prompt_type: prompt.type });
 	}
-	activeUpgradePrompt.set(null);
+	closeUpgradePrompt();
 };
 
 // Discount percentage to code mapping
@@ -767,6 +809,10 @@ export const getDiscountForUsage = (usagePercentage) => {
  */
 export const handleUpgradeClick = async (prompt, discount = null) => {
 	recordUpgradePrompt('clicked', prompt?.type || 'general', prompt);
+
+	// Close the prompt (without logging a dismissal) and free the slot before
+	// navigating, so the modal doesn't linger over the upgrade page.
+	closeUpgradePrompt();
 
 	// Track in PostHog
 	analytics.trackUpgradePromptClicked({


### PR DESCRIPTION
## Summary

Pair PR to pictify-io/html-to-gif#15. The PLG upsell components were mounted on the dashboard but never posted to `/api/plg/upgrade-prompt`, so production users showed `plgEngagement.upgradePromptsShown = 0` across the board — the funnel had no data.

This PR wires the engagement recording, then fixes the funnel-data accuracy that wiring exposed and coordinates the prompt surfaces so only one shows at a time.

## Changes

### 1. Wire engagement recording (`e3086e1`)
- **`UsageBanner.svelte`** — POST `shown` / `dismissed` / `clicked`.
- **`ProactiveUpgradeModal.svelte`** — POST `shown` when the ≥75% modal opens (with `discount_code` context), plus `dismissed` / `clicked`.
- **`MilestoneCelebration.svelte`** — POST `shown` / `dismissed` / `clicked` for upsell milestones (`soft_upsell` / `urgent_upsell` / `limit_reached`).
- **`plg.store.js` `refreshUsageWidget`** — detect render-count milestone crossings (1/5/10/25/40/50) and usage-% threshold crossings (50/65/75/85/95/100) between the existing 2-minute polls and dispatch the right surface.
- **`routes/dashboard/upgrade/+page.svelte`** — forward `discount_code` via `checkout[custom][discount_code]` so the webhook can attribute it, and optimistically POST `/api/plg/discount-code-used` at intent time.

### 2. Funnel-data accuracy (`7d983f9`)
- **`UsageBanner`** — record one `shown` per appearance, not per percentage tick. A free user climbing 65%→100% was firing ~17 `shown` POSTs for a single banner, inflating `upgradePromptsShown`.
- **`refreshUsageWidget`** — when usage jumps past several bands between polls, show the prompt for the user's **current** urgency (not the lowest band crossed), and surface the **highest** crossed render milestone (a 0→50 jump celebrates "maxed out", not "first render").
- **`MilestoneCelebration`** — the upgrade CTA recorded both `clicked` **and** `dismissed`; added `closeMilestone()` so a click logs only `clicked` (mutually exclusive funnel outcomes).

### 3. Single-prompt coordinator (`5852741`)
- Added a coordinator (`activePrompt` + `requestPrompt` / `releasePrompt`) in `plg.store`. The three interruptive modals (milestone, threshold/feature-limit upgrade modal, proactive modal) claim a single slot before showing and free it on close; non-preemptive (first claimant wins). The ambient usage banner is not a claimant — it observes `activePrompt` and steps aside while a modal is up.
- The poll tries the **threshold upgrade modal before the milestone**, so the actionable surface (tiered discount + upgrade CTA) wins the slot at high usage instead of the no-CTA celebration.
- Added `closeUpgradePrompt()`: the threshold/feature-limit CTA now closes the modal and frees the slot **before** navigating to `/dashboard/upgrade` (it previously lingered over the upgrade page and would have leaked the slot).

## Test plan
- [ ] Starter user, render past 65% → `UsageBanner` appears and POSTs `usage_banner/shown` **once** (DevTools network), not on every % tick.
- [ ] Render past 75% → either the threshold modal **or** `ProactiveUpgradeModal` shows — never both at once, and the banner hides behind it.
- [ ] Dismiss → POST `dismissed`. Click upgrade → POST `clicked` (no extra `dismissed`) and navigate to the upgrade page with the discount applied.
- [ ] Click upgrade with `EARLY5` → POST `/api/plg/discount-code-used`.

## Notes / follow-ups
- Discount attribution via `/api/plg/discount-code-used` requires the paired backend PR (pictify-io/html-to-gif#15) deployed. The client call degrades gracefully (errors are swallowed) until then.
- `recordDiscountCodeUsed` fires at intent-to-checkout, so `discountCodesUsed` reflects codes *applied*, not *redeemed*; the webhook is the authoritative post-payment signal.
- Pre-existing lint findings (a11y on modal backdrops, `no-empty` / `no-useless-catch`) left untouched.

## Verification
`prettier --check`, `eslint` (no new errors), and `vite build` all pass.

Closes [PIC-30](/PIC/issues/PIC-30) (frontend half).
