### PR TITLE
chore(governance): branch protection + CODEOWNERS + pre-push hook (PIC-38)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Pictify CODEOWNERS — every file requires review from a code owner.
+# Source: PIC-37 plan, Phase 1 (PIC-38).
+# Expand per-path when more reviewers exist.
+
+* @suyash-thakur

--- a/.github/workflows/protected-branch-guard.yml
+++ b/.github/workflows/protected-branch-guard.yml
@@ -1,0 +1,50 @@
+name: Protected Branch Guard
+
+# Belt-and-braces enforcement. If GitHub branch protection is ever relaxed,
+# this workflow fails any push to master/main whose head commit was not
+# introduced via a merge commit from a pull request.
+#
+# Source: PIC-37 plan §1.3 (Phase 1 — PIC-38).
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Refuse non-PR pushes to protected branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          echo "Validating push to $BRANCH ($SHA)…"
+
+          # The push event payload tells us if this came from a PR merge.
+          # GitHub does not natively flag direct pushes vs merge commits, so we
+          # ask the API: is this commit associated with a closed/merged PR?
+          PR_COUNT=$(gh api -H "Accept: application/vnd.github+json" \
+            "repos/${{ github.repository }}/commits/$SHA/pulls" \
+            --jq '[.[] | select(.merged_at != null)] | length')
+
+          if [ "$PR_COUNT" -lt 1 ]; then
+            echo "::error::Push to protected branch $BRANCH did not come from a merged pull request."
+            echo "Branch protection rules require PRs. See AGENTS.md > Git workflow (hard rules)."
+            exit 1
+          fi
+
+          echo "OK: commit $SHA was introduced via a merged PR."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+## Contributing
+
+This repo is governed by Pictify's [Git workflow hard rules](https://github.com/pictify-io/.github/blob/master/CONTRIBUTING.md). After cloning, point Git at the in-repo hooks once:
+
+```sh
+git config core.hooksPath scripts/githooks
+```
+
+That installs the `pre-push` hook which refuses direct pushes to `master`/`main`. All changes go through a pull request reviewed by a code owner (see `.github/CODEOWNERS`).

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+# scripts/githooks/pre-push
+#
+# Refuses direct pushes to protected branches (master/main). Forces agents
+# (and humans) to go through a pull request.
+#
+# Install with: git config core.hooksPath scripts/githooks
+# Source: PIC-37 plan §1.2 (Phase 1 — PIC-38).
+
+protected="refs/heads/master refs/heads/main"
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  for p in $protected; do
+    if [ "$remote_ref" = "$p" ]; then
+      echo "ERROR: direct push to protected branch '$remote_ref' is forbidden." >&2
+      echo "" >&2
+      echo "Open a PR from a feature branch instead." >&2
+      echo "Branch naming: agent/<agent-name-key>/<issue-identifier>-<slug>" >&2
+      echo "See AGENTS.md > Git workflow (hard rules) for full process." >&2
+      exit 1
+    fi
+  done
+done
+
+exit 0


### PR DESCRIPTION
## What & why

Phase 1 of the [PIC-37 plan](https://github.com/pictify-io) — same-day enforcement of "no agent merges to master without board approval". This PR ships the in-repo half: CODEOWNERS, a protected-branch-guard Actions workflow, a local pre-push hook, and a CONTRIBUTING note for installing it.

After this PR merges, branch protection rules are applied via `gh api` (see `pictify-ideas/scripts/apply-branch-protection.sh`).

## Changes

- `.github/CODEOWNERS` — `* @suyash-thakur` (sole reviewer until more engineers exist).
- `.github/workflows/protected-branch-guard.yml` — fails any push to master/main that did not come from a merged PR.
- `scripts/githooks/pre-push` — refuses direct pushes to refs/heads/master and refs/heads/main.
- `CONTRIBUTING.md` — one-liner to install the hooks path.

## Test plan

- Branch protection rules will be tested via the verification step in PIC-38.
- The pre-push hook is exercised locally next time anyone clones the repo and runs `git config core.hooksPath scripts/githooks`.

## Trailers

Paperclip-Issue: PIC-38
Paperclip-Agent: cto
Paperclip-Run: bootstrap